### PR TITLE
Fixed typo in .wav

### DIFF
--- a/examples/SDAudio/SdAudioRecording/myWAV.h
+++ b/examples/SDAudio/SdAudioRecording/myWAV.h
@@ -23,7 +23,7 @@ void playAudio(const char *audioFile) {
   uint32_t startPosition = 44;
 
   if (recFile) {
-    aaAudio.adcInterupts(false);
+    aaAudio.adcInterrupts(false);
     recFile.close();
   }
   


### PR DESCRIPTION
Previously, this file made a call to aaAudio.adcInterupts(), which doesn't exist. I fixed the typo (a missing r) to aaAudio.adcInterrupts().