### PR TITLE
add doxygen workflow; fix example links

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,46 @@
+name: DoxyGen build
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  release:
+    branches:
+      - master
+    types:
+      - published
+      - edited
+
+jobs:
+  build-doxygen:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: get latest release version number
+      id: latest_ver
+      uses: pozetroninc/github-action-get-latest-release@master
+      with:
+        repository:  TMRh20/AutoAnalogAudio
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: overwrite doxygen tags
+      run: |
+        mkdir docs
+        touch doxygenAction
+        echo "PROJECT_NUMBER = ${{ steps.latest_ver.outputs.release }}" >> doxygenAction
+        echo "OUTPUT_DIRECTORY = ./docs" >> doxygenAction
+        echo "@INCLUDE = doxygenAction" >> Doxyfile
+    - name: build doxygen
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+          working-directory: '.'
+          doxyfile-path: './Doxyfile'
+    - name: upload to github pages
+      if: ${{ github.event_name == 'release'}}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# docs folder
+docs/

--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "../../ArduinoBuilds/AAAudio Docs"
+OUTPUT_DIRECTORY       = ./docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -949,7 +949,8 @@ EXCLUDE_SYMLINKS       = NO
 
 EXCLUDE_PATTERNS       = readme* \
                          runtest* \
-                         tests*
+                         tests* \
+                         README*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the
@@ -967,8 +968,6 @@ EXCLUDE_SYMBOLS        =
 # command).
 
 EXAMPLE_PATH           = examples \
-                         examples/ESP32 \
-                         examples/ESP32/ESP32_AudioTest
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Automated analog reads and analog output (streaming) using Arduino DAC(or PWM), 
 
 **New** Now also supports AVR devices (Uno,Nano,Mega,etc) with pseudo DAC using PWM
 
-Plays and records analog (wav/pcm audio) data using onboard DAC and ADC. 
+Plays and records analog (wav/pcm audio) data using onboard DAC and ADC.
 Timers are adjusted automatically based on the rate of data delivery, to ensure smooth playback.
 DMA transfers used to maximize efficiency.
 
-Documentation: http://tmrh20.github.io/AAAudio/
-Also see: http://tmrh20.github.io/RF24Audio/
+Documentation: http://TMRh20.github.io/AutoAnalogAudio/
+Also see: http://nRF24.github.io/RF24Audio/
 
     AutoAnalogAudio streaming via DAC & ADC by TMRh20
     Copyright (C) 2016  TMRh20 - tmrh20@gmail.com, github.com/TMRh20

--- a/doxygen-custom.css
+++ b/doxygen-custom.css
@@ -1,295 +1,295 @@
 /* The standard CSS for doxygen */
 
 body, table, div, p, dl {
-	font-family: Lucida Grande, Verdana, Geneva, Arial, sans-serif;
-	font-size: 12px;
+    font-family: Lucida Grande, Verdana, Geneva, Arial, sans-serif;
+    font-size: 12px;
 }
 
 /* @group Heading Levels */
 
 h1 {
-	font-size: 150%;
+    font-size: 150%;
 }
 
 .title {
-	font-size: 150%;
-	font-weight: bold;
-	margin: 10px 2px;
+    font-size: 150%;
+    font-weight: bold;
+    margin: 10px 2px;
 }
 
 h2 {
-	font-size: 120%;
+    font-size: 120%;
 }
 
 h3 {
-	font-size: 100%;
+    font-size: 100%;
 }
 
 dt {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 div.multicol {
-	-moz-column-gap: 1em;
-	-webkit-column-gap: 1em;
-	-moz-column-count: 3;
-	-webkit-column-count: 3;
+    -moz-column-gap: 1em;
+    -webkit-column-gap: 1em;
+    -moz-column-count: 3;
+    -webkit-column-count: 3;
 }
 
 p.startli, p.startdd, p.starttd {
-	margin-top: 2px;
+    margin-top: 2px;
 }
 
 p.endli {
-	margin-bottom: 0px;
+    margin-bottom: 0px;
 }
 
 p.enddd {
-	margin-bottom: 4px;
+    margin-bottom: 4px;
 }
 
 p.endtd {
-	margin-bottom: 2px;
+    margin-bottom: 2px;
 }
 
 /* @end */
 
 caption {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 span.legend {
-        font-size: 70%;
-        text-align: center;
+    font-size: 70%;
+    text-align: center;
 }
 
 h3.version {
-        font-size: 90%;
-        text-align: center;
+    font-size: 90%;
+    text-align: center;
 }
 
-div.qindex, div.navtab{
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-	margin: 2px;
-	padding: 2px;
+div.qindex, div.navtab {
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    padding: 2px;
 }
 
 div.qindex, div.navpath {
-	width: 100%;
-	line-height: 110%;
+    width: 100%;
+    line-height: 110%;
 }
 
 div.navtab {
-	margin-right: 15px;
+    margin-right: 15px;
 }
 
 /* @group Link Styling */
 
 a {
-	color: #3D578C;
-	font-weight: normal;
-	text-decoration: none;
+    color: #3D578C;
+    font-weight: normal;
+    text-decoration: none;
 }
 
 .contents a:visited {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 a:hover {
-	text-decoration: underline;
+    text-decoration: underline;
 }
 
 a.qindex {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 a.qindexHL {
-	font-weight: bold;
-	background-color: #9CAFD4;
-	color: #ffffff;
-	border: 1px double #869DCA;
+    font-weight: bold;
+    background-color: #9CAFD4;
+    color: #ffffff;
+    border: 1px double #869DCA;
 }
 
 .contents a.qindexHL:visited {
-        color: #ffffff;
+    color: #ffffff;
 }
 
 a.el {
-	font-weight: bold;
+    font-weight: bold;
 }
 
 a.elRef {
 }
 
 a.code {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 a.codeRef {
-	color: #4665A2;
+    color: #4665A2;
 }
 
 /* @end */
 
 dl.el {
-	margin-left: -1cm;
+    margin-left: -1cm;
 }
 
 .fragment {
-	font-family: monospace, fixed;
-	font-size: 105%;
+    font-family: monospace, fixed;
+    font-size: 105%;
 }
 
 pre.fragment {
-	border: 1px solid #C4CFE5;
-	background-color: #FBFCFD;
-	padding: 4px 6px;
-	margin: 4px 8px 4px 2px;
-	overflow: auto;
-	word-wrap: break-word;
-	font-size:  9pt;
-	line-height: 125%;
+    border: 1px solid #C4CFE5;
+    background-color: #FBFCFD;
+    padding: 4px 6px;
+    margin: 4px 8px 4px 2px;
+    overflow: auto;
+    word-wrap: break-word;
+    font-size: 9pt;
+    line-height: 125%;
 }
 
 div.ah {
-	background-color: black;
-	font-weight: bold;
-	color: #ffffff;
-	margin-bottom: 3px;
-	margin-top: 3px;
-	padding: 0.2em;
-	border: solid thin #333;
-	border-radius: 0.5em;
-	-webkit-border-radius: .5em;
-	-moz-border-radius: .5em;
-	box-shadow: 2px 2px 3px #999;
-	-webkit-box-shadow: 2px 2px 3px #999;
-	-moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
-	background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000),color-stop(0.3, #444));
-	background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000);
+    background-color: black;
+    font-weight: bold;
+    color: #ffffff;
+    margin-bottom: 3px;
+    margin-top: 3px;
+    padding: 0.2em;
+    border: solid thin #333;
+    border-radius: 0.5em;
+    -webkit-border-radius: .5em;
+    -moz-border-radius: .5em;
+    box-shadow: 2px 2px 3px #999;
+    -webkit-box-shadow: 2px 2px 3px #999;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 2px 2px 2px;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#eee), to(#000), color-stop(0.3, #444));
+    background-image: -moz-linear-gradient(center top, #eee 0%, #444 40%, #000);
 }
 
 div.groupHeader {
-	margin-left: 16px;
-	margin-top: 12px;
-	font-weight: bold;
+    margin-left: 16px;
+    margin-top: 12px;
+    font-weight: bold;
 }
 
 div.groupText {
-	margin-left: 16px;
-	font-style: italic;
+    margin-left: 16px;
+    font-style: italic;
 }
 
 body {
-	background: white;
-	color: black;
-        margin: 0;
+    background: white;
+    color: black;
+    margin: 0;
 }
 
 div.contents {
-	margin-top: 10px;
-	margin-left: 10px;
-	margin-right: 5px;
+    margin-top: 10px;
+    margin-left: 10px;
+    margin-right: 5px;
 }
 
 td.indexkey {
-	background-color: #EBEFF6;
-	font-weight: bold;
-	border: 1px solid #C4CFE5;
-	margin: 2px 0px 2px 0;
-	padding: 2px 10px;
+    background-color: #EBEFF6;
+    font-weight: bold;
+    border: 1px solid #C4CFE5;
+    margin: 2px 0px 2px 0;
+    padding: 2px 10px;
 }
 
 td.indexvalue {
-	background-color: #EBEFF6;
-	border: 1px solid #C4CFE5;
-	padding: 2px 10px;
-	margin: 2px 0px;
+    background-color: #EBEFF6;
+    border: 1px solid #C4CFE5;
+    padding: 2px 10px;
+    margin: 2px 0px;
 }
 
 tr.memlist {
-	background-color: #EEF1F7;
+    background-color: #EEF1F7;
 }
 
 p.formulaDsp {
-	text-align: center;
+    text-align: center;
 }
 
 img.formulaDsp {
-	
+
 }
 
 img.formulaInl {
-	vertical-align: middle;
+    vertical-align: middle;
 }
 
 div.center {
-	text-align: center;
-        margin-top: 0px;
-        margin-bottom: 0px;
-        padding: 0px;
+    text-align: center;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding: 0px;
 }
 
 div.center img {
-	border: 0px;
+    border: 0px;
 }
 
 address.footer {
-	text-align: right;
-	padding-right: 12px;
+    text-align: right;
+    padding-right: 12px;
 }
 
 img.footer {
-	border: 0px;
-	vertical-align: middle;
+    border: 0px;
+    vertical-align: middle;
 }
 
 /* @group Code Colorization */
 
 span.keyword {
-	color: #008000
+    color: #008000
 }
 
 span.keywordtype {
-	color: #604020
+    color: #604020
 }
 
 span.keywordflow {
-	color: #e08000
+    color: #e08000
 }
 
 span.comment {
-	color: #800000
+    color: #800000
 }
 
 span.preprocessor {
-	color: #806020
+    color: #806020
 }
 
 span.stringliteral {
-	color: #002080
+    color: #002080
 }
 
 span.charliteral {
-	color: #008080
+    color: #008080
 }
 
-span.vhdldigit { 
-	color: #ff00ff 
+span.vhdldigit {
+    color: #ff00ff
 }
 
-span.vhdlchar { 
-	color: #000000 
+span.vhdlchar {
+    color: #000000
 }
 
-span.vhdlkeyword { 
-	color: #700070 
+span.vhdlkeyword {
+    color: #700070
 }
 
-span.vhdllogic { 
-	color: #ff0000 
+span.vhdllogic {
+    color: #ff0000
 }
 
 /* @end */
@@ -314,66 +314,66 @@ input.search {
 */
 
 td.tiny {
-	font-size: 75%;
+    font-size: 75%;
 }
 
 .dirtab {
-	padding: 4px;
-	border-collapse: collapse;
-	border: 1px solid #A3B4D7;
+    padding: 4px;
+    border-collapse: collapse;
+    border: 1px solid #A3B4D7;
 }
 
 th.dirtab {
-	background: #EBEFF6;
-	font-weight: bold;
+    background: #EBEFF6;
+    font-weight: bold;
 }
 
 hr {
-	height: 0px;
-	border: none;
-	border-top: 1px solid #4A6AAA;
+    height: 0px;
+    border: none;
+    border-top: 1px solid #4A6AAA;
 }
 
 hr.footer {
-	height: 1px;
+    height: 1px;
 }
 
 /* @group Member Descriptions */
 
 table.memberdecls {
-	border-spacing: 0px;
-	padding: 0px;
+    border-spacing: 0px;
+    padding: 0px;
 }
 
 .mdescLeft, .mdescRight,
 .memItemLeft, .memItemRight,
 .memTemplItemLeft, .memTemplItemRight, .memTemplParams {
-	background-color: #F9FAFC;
-	border: none;
-	margin: 4px;
-	padding: 1px 0 0 8px;
+    background-color: #F9FAFC;
+    border: none;
+    margin: 4px;
+    padding: 1px 0 0 8px;
 }
 
 .mdescLeft, .mdescRight {
-	padding: 0px 8px 4px 8px;
-	color: #555;
+    padding: 0px 8px 4px 8px;
+    color: #555;
 }
 
 .memItemLeft, .memItemRight, .memTemplParams {
-	border-top: 1px solid #C4CFE5;
+    border-top: 1px solid #C4CFE5;
 }
 
 .memItemLeft, .memTemplItemLeft {
-        white-space: nowrap;
+    white-space: nowrap;
 }
 
 .memItemRight {
-	width: 100%;
+    width: 100%;
 }
 
 .memTemplParams {
-	color: #4665A2;
-        white-space: nowrap;
+    color: #4665A2;
+    white-space: nowrap;
 }
 
 /* @end */
@@ -383,122 +383,121 @@ table.memberdecls {
 /* Styles for detailed member documentation */
 
 .memtemplate {
-	font-size: 80%;
-	color: #4665A2;
-	font-weight: normal;
-	margin-left: 9px;
+    font-size: 80%;
+    color: #4665A2;
+    font-weight: normal;
+    margin-left: 9px;
 }
 
 .memnav {
-	background-color: #EBEFF6;
-	border: 1px solid #A3B4D7;
-	text-align: center;
-	margin: 2px;
-	margin-right: 15px;
-	padding: 2px;
+    background-color: #EBEFF6;
+    border: 1px solid #A3B4D7;
+    text-align: center;
+    margin: 2px;
+    margin-right: 15px;
+    padding: 2px;
 }
 
 .mempage {
-	width: 100%;
+    width: 100%;
 }
 
 .memitem {
-	padding: 0;
-	margin-bottom: 10px;
-	margin-right: 5px;
+    padding: 0;
+    margin-bottom: 10px;
+    margin-right: 5px;
 }
 
 .memname {
-        white-space: nowrap;
-        font-weight: bold;
-        margin-left: 6px;
+    white-space: nowrap;
+    font-weight: bold;
+    margin-left: 6px;
 }
 
 .memproto {
-        border-top: 1px solid #A8B8D9;
-        border-left: 1px solid #A8B8D9;
-        border-right: 1px solid #A8B8D9;
-        padding: 6px 0px 6px 0px;
-        color: #253555;
-        font-weight: bold;
-        text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
-        /* opera specific markup */
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        border-top-right-radius: 8px;
-        border-top-left-radius: 8px;
-        /* firefox specific markup */
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        -moz-border-radius-topright: 8px;
-        -moz-border-radius-topleft: 8px;
-        /* webkit specific markup */
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        -webkit-border-top-right-radius: 8px;
-        -webkit-border-top-left-radius: 8px;
-        background-image:url('nav_f.png');
-        background-repeat:repeat-x;
-        background-color: #E2E8F2;
+    border-top: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 6px 0px 6px 0px;
+    color: #253555;
+    font-weight: bold;
+    text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+    /* opera specific markup */
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    border-top-right-radius: 8px;
+    border-top-left-radius: 8px;
+    /* firefox specific markup */
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    -moz-border-radius-topright: 8px;
+    -moz-border-radius-topleft: 8px;
+    /* webkit specific markup */
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    -webkit-border-top-right-radius: 8px;
+    -webkit-border-top-left-radius: 8px;
+    background-image: url('nav_f.png');
+    background-repeat: repeat-x;
+    background-color: #E2E8F2;
 
 }
 
 .memdoc {
-        border-bottom: 1px solid #A8B8D9;      
-        border-left: 1px solid #A8B8D9;      
-        border-right: 1px solid #A8B8D9; 
-        padding: 2px 5px;
-        background-color: #FBFCFD;
-        border-top-width: 0;
-        /* opera specific markup */
-        border-bottom-left-radius: 8px;
-        border-bottom-right-radius: 8px;
-        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        /* firefox specific markup */
-        -moz-border-radius-bottomleft: 8px;
-        -moz-border-radius-bottomright: 8px;
-        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
-        background-image: -moz-linear-gradient(center top, #FFFFFF 0%, #FFFFFF 60%, #F7F8FB 95%, #EEF1F7);
-        /* webkit specific markup */
-        -webkit-border-bottom-left-radius: 8px;
-        -webkit-border-bottom-right-radius: 8px;
-        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
-        background-image: -webkit-gradient(linear,center top,center bottom,from(#FFFFFF), color-stop(0.6,#FFFFFF), color-stop(0.60,#FFFFFF), color-stop(0.95,#F7F8FB), to(#EEF1F7));
+    border-bottom: 1px solid #A8B8D9;
+    border-left: 1px solid #A8B8D9;
+    border-right: 1px solid #A8B8D9;
+    padding: 2px 5px;
+    background-color: #FBFCFD;
+    border-top-width: 0;
+    /* opera specific markup */
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    /* firefox specific markup */
+    -moz-border-radius-bottomleft: 8px;
+    -moz-border-radius-bottomright: 8px;
+    -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+    background-image: -moz-linear-gradient(center top, #FFFFFF 0%, #FFFFFF 60%, #F7F8FB 95%, #EEF1F7);
+    /* webkit specific markup */
+    -webkit-border-bottom-left-radius: 8px;
+    -webkit-border-bottom-right-radius: 8px;
+    -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    background-image: -webkit-gradient(linear, center top, center bottom, from(#FFFFFF), color-stop(0.6, #FFFFFF), color-stop(0.60, #FFFFFF), color-stop(0.95, #F7F8FB), to(#EEF1F7));
 }
 
 .paramkey {
-	text-align: right;
+    text-align: right;
 }
 
 .paramtype {
-	white-space: nowrap;
+    white-space: nowrap;
 }
 
 .paramname {
-	color: #602020;
-	white-space: nowrap;
+    color: #602020;
+    white-space: nowrap;
 }
+
 .paramname em {
-	font-style: normal;
+    font-style: normal;
 }
 
 .params, .retval, .exception, .tparams {
-        border-spacing: 6px 2px;
-}       
+    border-spacing: 6px 2px;
+}
 
 .params .paramname, .retval .paramname {
-        font-weight: bold;
-        vertical-align: top;
+    font-weight: bold;
+    vertical-align: top;
 }
-        
+
 .params .paramtype {
-        font-style: italic;
-        vertical-align: top;
-}       
-        
-.params .paramdir {
-        font-family: "courier new",courier,monospace;
-        vertical-align: top;
+    font-style: italic;
+    vertical-align: top;
 }
 
-
+.params .paramdir {
+    font-family: "courier new", courier, monospace;
+    vertical-align: top;
+}
 
 
 /* @end */
@@ -508,22 +507,22 @@ table.memberdecls {
 /* for the tree view */
 
 .ftvtree {
-	font-family: sans-serif;
-	margin: 0px;
+    font-family: sans-serif;
+    margin: 0px;
 }
 
 /* these are for tree view when used as main index */
 
 .directory {
-	font-size: 9pt;
-	font-weight: bold;
-	margin: 5px;
+    font-size: 9pt;
+    font-weight: bold;
+    margin: 5px;
 }
 
 .directory h3 {
-	margin: 0px;
-	margin-top: 1em;
-	font-size: 11pt;
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
 }
 
 /*
@@ -545,291 +544,272 @@ proper pixel height of your image.
 */
 
 .directory > h3 {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .directory p {
-	margin: 0px;
-	white-space: nowrap;
+    margin: 0px;
+    white-space: nowrap;
 }
 
 .directory div {
-	display: none;
-	margin: 0px;
+    display: none;
+    margin: 0px;
 }
 
 .directory img {
-	vertical-align: -30%;
+    vertical-align: -30%;
 }
 
 /* these are for tree view when not used as main index */
 
 .directory-alt {
-	font-size: 100%;
-	font-weight: bold;
+    font-size: 100%;
+    font-weight: bold;
 }
 
 .directory-alt h3 {
-	margin: 0px;
-	margin-top: 1em;
-	font-size: 11pt;
+    margin: 0px;
+    margin-top: 1em;
+    font-size: 11pt;
 }
 
 .directory-alt > h3 {
-	margin-top: 0;
+    margin-top: 0;
 }
 
 .directory-alt p {
-	margin: 0px;
-	white-space: nowrap;
+    margin: 0px;
+    white-space: nowrap;
 }
 
 .directory-alt div {
-	display: none;
-	margin: 0px;
+    display: none;
+    margin: 0px;
 }
 
 .directory-alt img {
-	vertical-align: -30%;
+    vertical-align: -30%;
 }
 
 /* @end */
 
 div.dynheader {
-        margin-top: 8px;
+    margin-top: 8px;
 }
 
 address {
-	font-style: normal;
-	color: #2A3D61;
+    font-style: normal;
+    color: #2A3D61;
 }
 
 table.doxtable {
-	border-collapse:collapse;
+    border-collapse: collapse;
 }
 
 table.doxtable td, table.doxtable th {
-	border: 1px solid #2D4068;
-	padding: 3px 7px 2px;
+    border: 1px solid #2D4068;
+    padding: 3px 7px 2px;
 }
 
 table.doxtable th {
-	background-color: #374F7F;
-	color: #FFFFFF;
-	font-size: 110%;
-	padding-bottom: 4px;
-	padding-top: 5px;
-	text-align:left;
+    background-color: #374F7F;
+    color: #FFFFFF;
+    font-size: 110%;
+    padding-bottom: 4px;
+    padding-top: 5px;
+    text-align: left;
 }
 
 .tabsearch {
-	top: 0px;
-	left: 10px;
-	height: 36px;
-	background-image: url('tab_b.png');
-	z-index: 101;
-	overflow: hidden;
-	font-size: 13px;
+    top: 0px;
+    left: 10px;
+    height: 36px;
+    background-image: url('tab_b.png');
+    z-index: 101;
+    overflow: hidden;
+    font-size: 13px;
 }
 
-.navpath ul
-{
-	font-size: 11px;
-	background-image:url('tab_b.png');
-	background-repeat:repeat-x;
-	height:30px;
-	line-height:30px;
-	color:#8AA0CC;
-	border:solid 1px #C2CDE4;
-	overflow:hidden;
-	margin:0px;
-	padding:0px;
+.navpath ul {
+    font-size: 11px;
+    background-image: url('tab_b.png');
+    background-repeat: repeat-x;
+    height: 30px;
+    line-height: 30px;
+    color: #8AA0CC;
+    border: solid 1px #C2CDE4;
+    overflow: hidden;
+    margin: 0px;
+    padding: 0px;
 }
 
-.navpath li
-{
-	list-style-type:none;
-	float:left;
-	padding-left:10px;
-	padding-right:15px;
-	background-image:url('bc_s.png');
-	background-repeat:no-repeat;
-	background-position:right;
-	color:#364D7C;
+.navpath li {
+    list-style-type: none;
+    float: left;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: url('bc_s.png');
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
 }
 
-.navpath li.navelem a
-{
-	height:32px;
-	display:block;
-	text-decoration: none;
-	outline: none;
+.navpath li.navelem a {
+    height: 32px;
+    display: block;
+    text-decoration: none;
+    outline: none;
 }
 
-.navpath li.navelem a:hover
-{
-	color:#6884BD;
+.navpath li.navelem a:hover {
+    color: #6884BD;
 }
 
-.navpath li.footer
-{
-        list-style-type:none;
-        float:right;
-        padding-left:10px;
-        padding-right:15px;
-        background-image:none;
-        background-repeat:no-repeat;
-        background-position:right;
-        color:#364D7C;
-        font-size: 8pt;
+.navpath li.footer {
+    list-style-type: none;
+    float: right;
+    padding-left: 10px;
+    padding-right: 15px;
+    background-image: none;
+    background-repeat: no-repeat;
+    background-position: right;
+    color: #364D7C;
+    font-size: 8pt;
 }
 
 
-div.summary
-{
-	float: right;
-	font-size: 8pt;
-	padding-right: 5px;
-	width: 50%;
-	text-align: right;
-}       
-
-div.summary a
-{
-	white-space: nowrap;
+div.summary {
+    float: right;
+    font-size: 8pt;
+    padding-right: 5px;
+    width: 50%;
+    text-align: right;
 }
 
-div.ingroups
-{
-	font-size: 8pt;
-	padding-left: 5px;
-	width: 50%;
-	text-align: left;
+div.summary a {
+    white-space: nowrap;
 }
 
-div.ingroups a
-{
-	white-space: nowrap;
+div.ingroups {
+    font-size: 8pt;
+    padding-left: 5px;
+    width: 50%;
+    text-align: left;
 }
 
-div.header
-{
-        background-image:url('nav_h.png');
-        background-repeat:repeat-x;
-	background-color: #F9FAFC;
-	margin:  0px;
-	border-bottom: 1px solid #C4CFE5;
+div.ingroups a {
+    white-space: nowrap;
 }
 
-div.headertitle
-{
-	padding: 5px 5px 5px 10px;
+div.header {
+    background-image: url('nav_h.png');
+    background-repeat: repeat-x;
+    background-color: #F9FAFC;
+    margin: 0px;
+    border-bottom: 1px solid #C4CFE5;
 }
 
-dl
-{
-        padding: 0 0 0 10px;
+div.headertitle {
+    padding: 5px 5px 5px 10px;
 }
 
-dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug
-{
-        border-left:4px solid;
-        padding: 0 0 0 6px;
+dl {
+    padding: 0 0 0 10px;
 }
 
-dl.note
-{
-        border-color: #D0C000;
+dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug {
+    border-left: 4px solid;
+    padding: 0 0 0 6px;
 }
 
-dl.warning, dl.attention
-{
-        border-color: #FF0000;
+dl.note {
+    border-color: #D0C000;
 }
 
-dl.pre, dl.post, dl.invariant
-{
-        border-color: #00D000;
+dl.warning, dl.attention {
+    border-color: #FF0000;
 }
 
-dl.deprecated
-{
-        border-color: #505050;
+dl.pre, dl.post, dl.invariant {
+    border-color: #00D000;
 }
 
-dl.todo
-{
-        border-color: #00C0E0;
+dl.deprecated {
+    border-color: #505050;
 }
 
-dl.test
-{
-        border-color: #3030E0;
+dl.todo {
+    border-color: #00C0E0;
 }
 
-dl.bug
-{
-        border-color: #C08050;
+dl.test {
+    border-color: #3030E0;
 }
 
-#projectlogo
-{
-	text-align: center;
-	vertical-align: bottom;
-	border-collapse: separate;
-}
- 
-#projectlogo img
-{ 
-	border: 0px none;
-}
- 
-#projectname
-{
-	font: 300% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 2px 0px;
-}
-    
-#projectbrief
-{
-	font: 120% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
+dl.bug {
+    border-color: #C08050;
 }
 
-#projectnumber
-{
-	font: 50% Tahoma, Arial,sans-serif;
-	margin: 0px;
-	padding: 0px;
+#projectlogo {
+    text-align: center;
+    vertical-align: bottom;
+    border-collapse: separate;
 }
 
-#titlearea
-{
-	padding: 0px;
-	margin: 0px;
-	width: 100%;
-	border-bottom: 1px solid #5373B4;
+#projectlogo img {
+    border: 0px none;
 }
 
-.image
-{
-        text-align: left;
+#projectname {
+    font: 300% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 2px 0px;
 }
 
-.dotgraph
-{
-        text-align: center;
+#projectbrief {
+    font: 120% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
 }
 
-.mscgraph
-{
-        text-align: center;
+#projectnumber {
+    font: 50% Tahoma, Arial, sans-serif;
+    margin: 0px;
+    padding: 0px;
 }
 
-.caption
-{
-	font-weight: bold;
+#titlearea {
+    padding: 0px;
+    margin: 0px;
+    width: 100%;
+    border-bottom: 1px solid #5373B4;
 }
 
+.image {
+    text-align: left;
+}
+
+.dotgraph {
+    text-align: center;
+}
+
+.mscgraph {
+    text-align: center;
+}
+
+.caption {
+    font-weight: bold;
+}
+td.fielddoc
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone {
+    background-image: none;
+    border-radius: unset;
+}
+
+td.fielddoc tr:last-child {
+    border-bottom: 1px solid #2D4068;
+}

--- a/examples/AudioRadioRelay/AudioRadioRelay.ino
+++ b/examples/AudioRadioRelay/AudioRadioRelay.ino
@@ -15,9 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-* 
+*
 * Auto Analog Audio (Automatic DAC, ADC & Timer) library
-* 
+*
 * Features:
 * 1. Very simple user interface to Arduino DUE DAC and ADC
 * 2. PCM/WAV Audio/Analog Data playback using Arduino Due DAC
@@ -25,20 +25,20 @@
 * 4. Onboard timers drive the DAC & ADC automatically
 * 5. Automatic sample rate/timer adjustment based on rate of user-driven data requests/input
 * 6. Uses DMA (Direct Memory Access) to buffer DAC & ADC data
-* 
+*
 * Auto Analog Audio Library Information:
 * http://github.com/TMRh20
 * http://tmrh20.blogspot.com
-* 
+*
 * Audio Relay & Peripheral Test Example:
-* This example demonstrates how to manage incoming and outgoing audio streams using 
+* This example demonstrates how to manage incoming and outgoing audio streams using
 * the AAAudio library and nrf24l01+ radio modules on Arduino Due.
-* 
+*
 * 1. This example uses the onboard DAC to play the incoming audio data via DAC0
 * 2. The ADC is used to sample the DAC (connected to pin A0) and the data is made available
 * 3. The data is re-broadcast over the radios
 * 4. Incoming radio data can be directly re-broadcast, but this example is a test of all peripherals
-* 
+*
 */
 
 /************************USER CONFIG**********************/
@@ -55,7 +55,7 @@ AutoAnalog aaAudio;
 
 /*********************************************************/
 
-void DACC_Handler(void){ 
+void DACC_Handler(void){
   aaAudio.dacHandler();   //Link the DAC ISR/IRQ library. Called by the MCU when DAC is ready for data
 }
 
@@ -70,7 +70,7 @@ void setup() {
   #if defined (ARDUINO_AVR)
     aaAudio.autoAdjust = 0;
   #endif
-  setupRadio();  
+  setupRadio();
 }
 
 
@@ -83,14 +83,14 @@ void loop() {
   //Display the timer period variable for each channel every 3 seconds
   if(millis() - dispTimer > 3000){
     dispTimer = millis();
-    
+
     #if !defined (ARDUINO_ARCH_AVR)
       TcChannel * t = &(TC0->TC_CHANNEL)[0];
       TcChannel * tt= &(TC0->TC_CHANNEL)[1];
-    
-      Serial.print("Ch0:"); 
-      Serial.println(t->TC_RC);      
-      Serial.print("Ch1:"); 
+
+      Serial.print("Ch0:");
+      Serial.println(t->TC_RC);
+      Serial.print("Ch1:");
       Serial.println(tt->TC_RC);
     #else
       Serial.print("Ch0/1:");
@@ -105,33 +105,33 @@ uint32_t dynSampleRate = 0;
 
 // See myRadio.h: Function is attached to an interrupt triggered by radio RX/TX
 void RX(){
-    
+
   if(radio.available(&pipeNo)){             // Check for data and get the pipe number
 
-    if(pipeNo == 2){      
+    if(pipeNo == 2){
       radio.read(&dynSampleRate,4);         // Receive commands using pipe #2
-      aaAudio.setSampleRate(dynSampleRate); // Pipe 2 is being used for command data, pipe 1 & others for audio data    
+      aaAudio.setSampleRate(dynSampleRate); // Pipe 2 is being used for command data, pipe 1 & others for audio data
     }else{
 
       #if !defined (ARDUINO_ARCH_AVR)         //AVR (Uno, Nano can't handle extra processing)
         radio.stopListening();                // Prepare to send data out via radio
-      #endif  
-      radio.read(&aaAudio.dacBuffer,32);      // Read the available radio data   
-      
-      aaAudio.feedDAC(0,32);                  // Feed the DAC with the received data      
+      #endif
+      radio.read(&aaAudio.dacBuffer,32);      // Read the available radio data
+
+      aaAudio.feedDAC(0,32);                  // Feed the DAC with the received data
 
       #if !defined (ARDUINO_ARCH_AVR)
       aaAudio.getADC(32);                     // Grab the available data from the ADC
 
-      //Send the received ADC data via radio      
-      radio.startFastWrite(&aaAudio.adcBuffer,32,1);
+      //Send the received ADC data via radio
+      radio.startFastWrite(&aaAudio.adcBuffer,32, 1);
       #endif
 
     /*Note: The data initially recieved can directly be sent via radio, but
                this example is a test of all library peripherals               */
 
     }
-  }else{  //If not RX IRQ, must be TX complete    
+  }else{  //If not RX IRQ, must be TX complete
     radio.txStandBy();                      // Set the radio to standby mode from TX
     radio.startListening();                 // Put the radio into listening (RX) mode
   }

--- a/examples/AudioRadioRelay/AudioRadioRelay.ino
+++ b/examples/AudioRadioRelay/AudioRadioRelay.ino
@@ -55,7 +55,7 @@ AutoAnalog aaAudio;
 
 /*********************************************************/
 
-void DACC_Handler(void){
+void DACC_Handler(void) {
   aaAudio.dacHandler();   //Link the DAC ISR/IRQ library. Called by the MCU when DAC is ready for data
 }
 
@@ -66,10 +66,10 @@ void setup() {
   Serial.begin(115200);
   Serial.println("Analog Audio Begin");
 
-  aaAudio.begin(1,1);   //Setup aaAudio using both DAC and ADC
-  #if defined (ARDUINO_AVR)
-    aaAudio.autoAdjust = 0;
-  #endif
+  aaAudio.begin(1, 1);  //Setup aaAudio using both DAC and ADC
+#if defined (ARDUINO_AVR)
+  aaAudio.autoAdjust = 0;
+#endif
   setupRadio();
 }
 
@@ -81,21 +81,21 @@ uint32_t dispTimer = 0;
 void loop() {
 
   //Display the timer period variable for each channel every 3 seconds
-  if(millis() - dispTimer > 3000){
+  if (millis() - dispTimer > 3000) {
     dispTimer = millis();
 
-    #if !defined (ARDUINO_ARCH_AVR)
-      TcChannel * t = &(TC0->TC_CHANNEL)[0];
-      TcChannel * tt= &(TC0->TC_CHANNEL)[1];
+#if !defined (ARDUINO_ARCH_AVR)
+    TcChannel * t = &(TC0->TC_CHANNEL)[0];
+    TcChannel * tt = &(TC0->TC_CHANNEL)[1];
 
-      Serial.print("Ch0:");
-      Serial.println(t->TC_RC);
-      Serial.print("Ch1:");
-      Serial.println(tt->TC_RC);
-    #else
-      Serial.print("Ch0/1:");
-      Serial.println(ICR1);
-    #endif
+    Serial.print("Ch0:");
+    Serial.println(t->TC_RC);
+    Serial.print("Ch1:");
+    Serial.println(tt->TC_RC);
+#else
+    Serial.print("Ch0/1:");
+    Serial.println(ICR1);
+#endif
   }
 }
 
@@ -104,34 +104,34 @@ void loop() {
 uint32_t dynSampleRate = 0;
 
 // See myRadio.h: Function is attached to an interrupt triggered by radio RX/TX
-void RX(){
+void RX() {
 
-  if(radio.available(&pipeNo)){             // Check for data and get the pipe number
+  if (radio.available(&pipeNo)) {           // Check for data and get the pipe number
 
-    if(pipeNo == 2){
-      radio.read(&dynSampleRate,4);         // Receive commands using pipe #2
+    if (pipeNo == 2) {
+      radio.read(&dynSampleRate, 4);        // Receive commands using pipe #2
       aaAudio.setSampleRate(dynSampleRate); // Pipe 2 is being used for command data, pipe 1 & others for audio data
-    }else{
+    } else {
 
-      #if !defined (ARDUINO_ARCH_AVR)         //AVR (Uno, Nano can't handle extra processing)
-        radio.stopListening();                // Prepare to send data out via radio
-      #endif
-      radio.read(&aaAudio.dacBuffer,32);      // Read the available radio data
+#if !defined (ARDUINO_ARCH_AVR)         //AVR (Uno, Nano can't handle extra processing)
+      radio.stopListening();                // Prepare to send data out via radio
+#endif
+      radio.read(&aaAudio.dacBuffer, 32);     // Read the available radio data
 
-      aaAudio.feedDAC(0,32);                  // Feed the DAC with the received data
+      aaAudio.feedDAC(0, 32);                 // Feed the DAC with the received data
 
-      #if !defined (ARDUINO_ARCH_AVR)
+#if !defined (ARDUINO_ARCH_AVR)
       aaAudio.getADC(32);                     // Grab the available data from the ADC
 
       //Send the received ADC data via radio
-      radio.startFastWrite(&aaAudio.adcBuffer,32, 1);
-      #endif
+      radio.startFastWrite(&aaAudio.adcBuffer, 32, 1);
+#endif
 
-    /*Note: The data initially recieved can directly be sent via radio, but
-               this example is a test of all library peripherals               */
+      /*Note: The data initially recieved can directly be sent via radio, but
+                 this example is a test of all library peripherals               */
 
     }
-  }else{  //If not RX IRQ, must be TX complete
+  } else { //If not RX IRQ, must be TX complete
     radio.txStandBy();                      // Set the radio to standby mode from TX
     radio.startListening();                 // Put the radio into listening (RX) mode
   }

--- a/examples/AudioRadioRelay/myRadio.h
+++ b/examples/AudioRadioRelay/myRadio.h
@@ -2,17 +2,17 @@
 
 #include <RF24.h>
 
-RF24 radio(radioCEPin,radioCSPin);
+RF24 radio(radioCEPin, radioCSPin);
 
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL };
+const uint64_t pipes[14] = {0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL};
 
-bool tx,fail,rx;
+bool tx, fail, rx;
 uint8_t pipeNo = 0;
 
 void RX();
 
 void setupRadio(){
-  
+
   radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_MAX);
@@ -20,19 +20,19 @@ void setupRadio(){
   radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
-  radio.openReadingPipe(1,pipes[1]);
-  radio.openReadingPipe(2,pipes[2]);
-  radio.setAutoAck(2,1);
+  radio.openReadingPipe(1, pipes[1]);
+  radio.openReadingPipe(2, pipes[2]);
+  radio.setAutoAck(2, 1);
   radio.openWritingPipe(pipes[0]);
   radio.txDelay = 0;
   radio.csDelay = 0;
-  radio.maskIRQ(0,1,0);
+  radio.maskIRQ(0, 1, 0);
   radio.printDetails();
 
   radio.startListening();
 
-  attachInterrupt(digitalPinToInterrupt(radioInterruptPin),RX,FALLING);
-  
+  attachInterrupt(digitalPinToInterrupt(radioInterruptPin), RX, FALLING);
+
 }
 
 

--- a/examples/AudioRadioRelay/myRadio.h
+++ b/examples/AudioRadioRelay/myRadio.h
@@ -11,7 +11,7 @@ uint8_t pipeNo = 0;
 
 void RX();
 
-void setupRadio(){
+void setupRadio() {
 
   radio.begin();
   radio.setChannel(1);

--- a/examples/ESP32/ESP32_AudioTest/ESP32_AudioTest.ino
+++ b/examples/ESP32/ESP32_AudioTest/ESP32_AudioTest.ino
@@ -13,7 +13,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <Arduino.h>
@@ -44,20 +44,20 @@ bool doADC = false;
 bool firstADC = false;
 
 void setup() {
-  
+
   Serial.begin(57600);
-  
+
   if (!SD.begin(SD_CS_PIN)) {
     Serial.println("SD init failed!");
     //return;
   }
   Serial.println("SD ok\nAnalog Audio Begin");
-  
+
   aaAudio.begin(1, 1);     // Start AAAudio with only the DAC (ADC,DAC,External ADC)
   aaAudio.autoAdjust = 0;  // Disable automatic timer adjustment
   aaAudio.setSampleRate(80000);
   aaAudio.dacBitsPerSample = 8;
-  
+
 }
 
 /*********************************************************/
@@ -69,43 +69,43 @@ bool doExtADC = false;
 bool doSine = false;
 
 /*********************************************************/
-uint32_t testCounter=0;
+uint32_t testCounter = 0;
 
 void loop() {
 
 
-    if(doADC){
-      aaAudio.getADC(adcReadings);
-      //The first call to getADC will not return proper values, so do not write samples to the DAC
-      if(!firstADC){
-      for(int i=0; i<adcReadings; i++){
+  if (doADC) {
+    aaAudio.getADC(adcReadings);
+    //The first call to getADC will not return proper values, so do not write samples to the DAC
+    if (!firstADC) {
+      for (int i = 0; i < adcReadings; i++) {
         //Volume control:
         //a: Convert unsigned 12-bit ADC output to signed
         //b: Divide by volume modifier, convert back to unsigned
         //c: Downshift to 8-bits
         //d: Feed into the DAC
-        
+
         int16_t tmpVar = (int16_t)aaAudio.adcBuffer16[i] - 0x800;
         tmpVar = (tmpVar / volumeVar) + 0x800;
         aaAudio.dacBuffer[i] = (uint8_t)(tmpVar >> 4);
         //aaAudio.dacBuffer[i] = aaAudio.adcBuffer16[i];
 
       }
-      aaAudio.feedDAC(0,adcReadings);
+      aaAudio.feedDAC(0, adcReadings);
 
-      }else{
-        firstADC = false;
-        memset(aaAudio.dacBuffer,0,MAX_BUFFER_SIZE);
-        aaAudio.feedDAC(0,MAX_BUFFER_SIZE);
-        aaAudio.feedDAC(0,MAX_BUFFER_SIZE);
+    } else {
+      firstADC = false;
+      memset(aaAudio.dacBuffer, 0, MAX_BUFFER_SIZE);
+      aaAudio.feedDAC(0, MAX_BUFFER_SIZE);
+      aaAudio.feedDAC(0, MAX_BUFFER_SIZE);
 
-      }
     }
-
-  if(doSine){
-    aaAudio.feedDAC(0,32);
   }
-  
+
+  if (doSine) {
+    aaAudio.feedDAC(0, 32);
+  }
+
   if (Serial.available()) {
     char input = Serial.read();
     switch (input) {
@@ -114,15 +114,21 @@ void loop() {
       case '2':  playAudio("/M8b24kS.wav");  break; //Play  16bit, 32khz, Stereo
       case '3':  playAudio("/M8b44kST.wav"); break; //Play 16bit, 44khz, Mono
       case '4':  playAudio("/M16b24kS.wav"); break; //Play  16bit, 44khz, Stereo
-      //Note: Audio playback should be stopped before engaging the ADC->DAC output  
-      case '5':  doADC = !doADC; if(doADC){ firstADC = true; aaAudio.setSampleRate(88200); aaAudio.dacBitsPerSample = 8; }else{ aaAudio.disableDAC(); }  break;
+      //Note: Audio playback should be stopped before engaging the ADC->DAC output
+      case '5':  doADC = !doADC; if (doADC) {
+          firstADC = true;
+          aaAudio.setSampleRate(88200);
+          aaAudio.dacBitsPerSample = 8;
+        } else {
+          aaAudio.disableDAC();
+        }  break;
       case '6':  volume(1); break;
       case '7':  volume(0); break;
       case '8':  volumeSet(1); break;
       case '9':  volumeSet(5); break;
       case '0':  playAudio("/calibrat.wav"); break;
       //Note: Switching the use of tasks while audio is playing will cause problems
-      case 't':  useTasks=!useTasks; Serial.print("Using Tasks: "); Serial.println(useTasks ? "True" : "False"); break;
+      case 't':  useTasks = !useTasks; Serial.print("Using Tasks: "); Serial.println(useTasks ? "True" : "False"); break;
       case 'e':  adcReadings = 32; break;
       case 'r':  adcReadings = MAX_BUFFER_SIZE; break;
       case 'a':  Serial.println("Manual Close"); aaAudio.rampOut(0); aaAudio.disableDAC(); myFile.close(); break;
@@ -133,16 +139,16 @@ void loop() {
   }
 
   //If tasks are disabled, handle loading of data and feeding DAC from main loop
-  if(!useTasks){
+  if (!useTasks) {
     DACC_Handler();
   }
 
   //Simple heartbeat to show activity
-  if(millis() - printTimer > 500){
+  if (millis() - printTimer > 500) {
     printTimer = millis();
     Serial.print(".");
     count++;
-    if(count >= 50){
+    if (count >= 50) {
       count = 0;
       Serial.println("");
     }

--- a/examples/ESP32/ESP32_AudioTest/mySine.h
+++ b/examples/ESP32/ESP32_AudioTest/mySine.h
@@ -1,75 +1,75 @@
 
 
-void sineSetup16(){
+void sineSetup16() {
 
-aaAudio.dacBuffer16[0] = 0x4000 >> 8;
-aaAudio.dacBuffer16[1] = 0x4c7c >> 8;
-aaAudio.dacBuffer16[2] = 0x587d >> 8;
-aaAudio.dacBuffer16[3] = 0x638e >> 8;
-aaAudio.dacBuffer16[4] = 0x6d40 >> 8;
-aaAudio.dacBuffer16[5] = 0x7536 >> 8;
-aaAudio.dacBuffer16[6] = 0x7b20 >> 8;
-aaAudio.dacBuffer16[7] = 0x7ec4 >> 8;
-aaAudio.dacBuffer16[8] = 0x7fff >> 8;
-aaAudio.dacBuffer16[9] = 0x7ec4 >> 8;
-aaAudio.dacBuffer16[10] = 0x7b20 >> 8;
-aaAudio.dacBuffer16[11] = 0x7536 >> 8;
-aaAudio.dacBuffer16[12] = 0x6d40 >> 8;
-aaAudio.dacBuffer16[13] = 0x638e >> 8;
-aaAudio.dacBuffer16[14] = 0x587d >> 8;
-aaAudio.dacBuffer16[15] = 0x4c7c >> 8;
-aaAudio.dacBuffer16[16] = 0x4000 >> 8;
-aaAudio.dacBuffer16[17] = 0x3383 >> 8;
-aaAudio.dacBuffer16[18] = 0x2782 >> 8;
-aaAudio.dacBuffer16[19] = 0x1c71 >> 8;
-aaAudio.dacBuffer16[20] = 0x12bf >> 8;
-aaAudio.dacBuffer16[21] = 0xac9 >> 8;
-aaAudio.dacBuffer16[22] = 0x4df >> 8;
-aaAudio.dacBuffer16[23] = 0x13b >> 8;
-aaAudio.dacBuffer16[24] = 0x0 >> 8;
-aaAudio.dacBuffer16[25] = 0x13b >> 8;
-aaAudio.dacBuffer16[26] = 0x4df >> 8;
-aaAudio.dacBuffer16[27] = 0xac9 >> 8;
-aaAudio.dacBuffer16[28] = 0x12bf >> 8;
-aaAudio.dacBuffer16[29] = 0x1c71 >> 8;
-aaAudio.dacBuffer16[30] = 0x2782 >> 8;
-aaAudio.dacBuffer16[31] = 0x3383 >> 8;
+  aaAudio.dacBuffer16[0] = 0x4000 >> 8;
+  aaAudio.dacBuffer16[1] = 0x4c7c >> 8;
+  aaAudio.dacBuffer16[2] = 0x587d >> 8;
+  aaAudio.dacBuffer16[3] = 0x638e >> 8;
+  aaAudio.dacBuffer16[4] = 0x6d40 >> 8;
+  aaAudio.dacBuffer16[5] = 0x7536 >> 8;
+  aaAudio.dacBuffer16[6] = 0x7b20 >> 8;
+  aaAudio.dacBuffer16[7] = 0x7ec4 >> 8;
+  aaAudio.dacBuffer16[8] = 0x7fff >> 8;
+  aaAudio.dacBuffer16[9] = 0x7ec4 >> 8;
+  aaAudio.dacBuffer16[10] = 0x7b20 >> 8;
+  aaAudio.dacBuffer16[11] = 0x7536 >> 8;
+  aaAudio.dacBuffer16[12] = 0x6d40 >> 8;
+  aaAudio.dacBuffer16[13] = 0x638e >> 8;
+  aaAudio.dacBuffer16[14] = 0x587d >> 8;
+  aaAudio.dacBuffer16[15] = 0x4c7c >> 8;
+  aaAudio.dacBuffer16[16] = 0x4000 >> 8;
+  aaAudio.dacBuffer16[17] = 0x3383 >> 8;
+  aaAudio.dacBuffer16[18] = 0x2782 >> 8;
+  aaAudio.dacBuffer16[19] = 0x1c71 >> 8;
+  aaAudio.dacBuffer16[20] = 0x12bf >> 8;
+  aaAudio.dacBuffer16[21] = 0xac9 >> 8;
+  aaAudio.dacBuffer16[22] = 0x4df >> 8;
+  aaAudio.dacBuffer16[23] = 0x13b >> 8;
+  aaAudio.dacBuffer16[24] = 0x0 >> 8;
+  aaAudio.dacBuffer16[25] = 0x13b >> 8;
+  aaAudio.dacBuffer16[26] = 0x4df >> 8;
+  aaAudio.dacBuffer16[27] = 0xac9 >> 8;
+  aaAudio.dacBuffer16[28] = 0x12bf >> 8;
+  aaAudio.dacBuffer16[29] = 0x1c71 >> 8;
+  aaAudio.dacBuffer16[30] = 0x2782 >> 8;
+  aaAudio.dacBuffer16[31] = 0x3383 >> 8;
 
 }
 
-void sineSetup8(){
+void sineSetup8() {
 
-aaAudio.dacBuffer[0] = 0x40;
-aaAudio.dacBuffer[1] = 0x4c;
-aaAudio.dacBuffer[2] = 0x58;
-aaAudio.dacBuffer[3] = 0x63;
-aaAudio.dacBuffer[4] = 0x6c;
-aaAudio.dacBuffer[5] = 0x74;
-aaAudio.dacBuffer[6] = 0x7a;
-aaAudio.dacBuffer[7] = 0x7e;
-aaAudio.dacBuffer[8] = 0x7f;
-aaAudio.dacBuffer[9] = 0x7e;
-aaAudio.dacBuffer[10] = 0x7a;
-aaAudio.dacBuffer[11] = 0x74;
-aaAudio.dacBuffer[12] = 0x6c;
-aaAudio.dacBuffer[13] = 0x63;
-aaAudio.dacBuffer[14] = 0x58;
-aaAudio.dacBuffer[15] = 0x4c;
-aaAudio.dacBuffer[16] = 0x40;
-aaAudio.dacBuffer[17] = 0x33;
-aaAudio.dacBuffer[18] = 0x27;
-aaAudio.dacBuffer[19] = 0x1c;
-aaAudio.dacBuffer[20] = 0x13;
-aaAudio.dacBuffer[21] = 0xb;
-aaAudio.dacBuffer[22] = 0x5;
-aaAudio.dacBuffer[23] = 0x1;
-aaAudio.dacBuffer[24] = 0x0;
-aaAudio.dacBuffer[25] = 0x1;
-aaAudio.dacBuffer[26] = 0x5;
-aaAudio.dacBuffer[27] = 0xb;
-aaAudio.dacBuffer[28] = 0x13;
-aaAudio.dacBuffer[29] = 0x1c;
-aaAudio.dacBuffer[30] = 0x27;
-aaAudio.dacBuffer[31] = 0x33;
+  aaAudio.dacBuffer[0] = 0x40;
+  aaAudio.dacBuffer[1] = 0x4c;
+  aaAudio.dacBuffer[2] = 0x58;
+  aaAudio.dacBuffer[3] = 0x63;
+  aaAudio.dacBuffer[4] = 0x6c;
+  aaAudio.dacBuffer[5] = 0x74;
+  aaAudio.dacBuffer[6] = 0x7a;
+  aaAudio.dacBuffer[7] = 0x7e;
+  aaAudio.dacBuffer[8] = 0x7f;
+  aaAudio.dacBuffer[9] = 0x7e;
+  aaAudio.dacBuffer[10] = 0x7a;
+  aaAudio.dacBuffer[11] = 0x74;
+  aaAudio.dacBuffer[12] = 0x6c;
+  aaAudio.dacBuffer[13] = 0x63;
+  aaAudio.dacBuffer[14] = 0x58;
+  aaAudio.dacBuffer[15] = 0x4c;
+  aaAudio.dacBuffer[16] = 0x40;
+  aaAudio.dacBuffer[17] = 0x33;
+  aaAudio.dacBuffer[18] = 0x27;
+  aaAudio.dacBuffer[19] = 0x1c;
+  aaAudio.dacBuffer[20] = 0x13;
+  aaAudio.dacBuffer[21] = 0xb;
+  aaAudio.dacBuffer[22] = 0x5;
+  aaAudio.dacBuffer[23] = 0x1;
+  aaAudio.dacBuffer[24] = 0x0;
+  aaAudio.dacBuffer[25] = 0x1;
+  aaAudio.dacBuffer[26] = 0x5;
+  aaAudio.dacBuffer[27] = 0xb;
+  aaAudio.dacBuffer[28] = 0x13;
+  aaAudio.dacBuffer[29] = 0x1c;
+  aaAudio.dacBuffer[30] = 0x27;
+  aaAudio.dacBuffer[31] = 0x33;
 
 }

--- a/examples/ESP32/ESP32_AudioTest/volume.h
+++ b/examples/ESP32/ESP32_AudioTest/volume.h
@@ -3,35 +3,34 @@ float volumeVar = 1.00;
 
 
 
-void volume(bool val){
+void volume(bool val) {
 
-  if(val){
-    if(volumeVar < 15){
+  if (val) {
+    if (volumeVar < 15) {
       volumeVar = volumeVar - 0.1 >= 1.0 ? volumeVar - 0.1 : volumeVar;
-    }else{
+    } else {
       volumeVar -= 1;
     }
-  }else{
-    if(volumeVar < 15){
+  } else {
+    if (volumeVar < 15) {
       volumeVar += .1;
-    }else
-    if(volumeVar < 127){
+    } else if (volumeVar < 127) {
       volumeVar += 1;
     }
   }
   Serial.println(volumeVar);
   //Note: 50% digital reduction may not equal 50% reduction in audible sound output
   Serial.print("Volume Setting: ");
-  Serial.print((128-volumeVar)/127.0*100);
+  Serial.print((128 - volumeVar) / 127.0 * 100);
   Serial.println("%");
 }
 
-void volumeSet(float val){
+void volumeSet(float val) {
 
-  if(val >= 1 && val <= 127){
+  if (val >= 1 && val <= 127) {
     volumeVar = val;
     Serial.print("Volume Setting: ");
-    Serial.print((128-volumeVar)/127.0*100);
-    Serial.println("%");    
+    Serial.print((128 - volumeVar) / 127.0 * 100);
+    Serial.println("%");
   }
 }

--- a/examples/SDAudio/SdAudioAuto/SdAudioAuto.ino
+++ b/examples/SDAudio/SdAudioAuto/SdAudioAuto.ino
@@ -68,9 +68,9 @@ void loop() {
   if (Serial.available()) {
     char input = Serial.read();
     switch (input) {
-                 //Play an 8-bit, 22Khz, Stereo WAV file
+      //Play an 8-bit, 22Khz, Stereo WAV file
       case '1':  aaAudio.dacBitsPerSample = 8;  aaAudio.setSampleRate(24000); playAudio("M8b24kM.wav");  break;
-                 //Play an 8-bit, 32Khz, Stereo WAV file
+      //Play an 8-bit, 32Khz, Stereo WAV file
       case '2':  aaAudio.dacBitsPerSample = 8;  aaAudio.setSampleRate(48000); playAudio("M8b24kS.wav");  break;
       case '3':  channelSelection = 0;  break;
       case '4':  channelSelection = 1;  break;
@@ -107,13 +107,13 @@ void playAudio(char *audioFile) {
 /* Function called from DAC interrupt after dacHandler(). Loads data into the dacBuffer */
 
 void loadBuffer() {
-  
+
   if (myFile) {
     if (myFile.available()) {
       if (aaAudio.dacBitsPerSample == 8) {
         //Load 32 samples into the 8-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer, MAX_BUFFER_SIZE);
-      }else{
+      } else {
         //Load 32 samples (64 bytes) into the 16-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer16, MAX_BUFFER_SIZE * 2);
         //Convert the 16-bit samples to 12-bit
@@ -121,7 +121,7 @@ void loadBuffer() {
           aaAudio.dacBuffer16[i] = (aaAudio.dacBuffer16[i] + 0x8000) >> 4;
         }
       }
-    }else{
+    } else {
       myFile.close();
       dacc_disable_interrupt(DACC, DACC_IER_ENDTX);
     }

--- a/examples/SDAudio/SdAudioBasic/SdAudioBasic.ino
+++ b/examples/SDAudio/SdAudioBasic/SdAudioBasic.ino
@@ -46,28 +46,28 @@ void setup() {
     return;
   }
   Serial.println("init ok");
-  
+
   Serial.println("Analog Audio Begin");
   aaAudio.begin(0, 1);  //Setup aaAudio using DAC
   aaAudio.autoAdjust = 0;
-  
+
   //Setup for audio at 8-bit, 16khz, mono
   aaAudio.dacBitsPerSample = 8;
   aaAudio.setSampleRate(16000);
-  
+
 }
 
 void loop() {
 
-  if(Serial.available()){
+  if (Serial.available()) {
     char input = Serial.read();
-    switch(input){
+    switch (input) {
       case '1': playAudio("M8b24kM.wav"); break;  //Play a *.wav file by name - 8bit, 24khz, Mono
       case '2': playAudio("M8b24kS.wav"); break;  //Play  8bit, 24khz, Stereo
       case '3': playAudio("audio.wav");   break;  //Play a random file called audio.wav
     }
   }
-  
+
   loadBuffer();
 }
 
@@ -77,29 +77,29 @@ void loop() {
 
 File myFile;
 
-void playAudio(char *audioFile){
+void playAudio(char *audioFile) {
 
   if (myFile) {
     myFile.close();
   }
   //Open the designated file
   myFile = SD.open(audioFile);
-  
+
   //Skip past the WAV header
   myFile.seek(44);
   loadBuffer();
-  
+
 }
 
-void loadBuffer(){
+void loadBuffer() {
   //Load 32 samples into the 8-bit dacBuffer
-  if(myFile.available()){
-    for(int i=0;i<32;i++){
+  if (myFile.available()) {
+    for (int i = 0; i < 32; i++) {
       aaAudio.dacBuffer[i] = myFile.read();
     }
     //Feed the dac with the buffer of data
-    aaAudio.feedDAC(0,32);
-  }  
-  
+    aaAudio.feedDAC(0, 32);
+  }
+
 }
 

--- a/examples/SDAudio/SdAudioRecording/SdAudioRecording.ino
+++ b/examples/SDAudio/SdAudioRecording/SdAudioRecording.ino
@@ -24,7 +24,7 @@
   SDAudioWavRecorder Example: (Higher quality recording requires Arduino Due or better)
   This example demonstrates a simple method to record WAV format files that will play back on any PC or audio device
   The default format is 8-bit, 11khz, Mono and can be adjusted as desired
-  
+
 */
 
 /******** User Config ************************************/
@@ -49,15 +49,15 @@ File recFile;
 /*********************************************************/
 
 void setup() {
-  
+
   Serial.begin(115200);
-  
+
   if (!SD.begin(SD_CS_PIN)) {
     Serial.println("SD init failed!");
     return;
   }
   Serial.println("SD ok\nAnalog Audio Begin");
-  
+
   aaAudio.begin(1, 1);     // Start AAAudio with ADC & DAC
   aaAudio.autoAdjust = 0;  // Disable automatic timer adjustment
 
@@ -68,9 +68,9 @@ uint32_t displayTimer = 0;
 
 void loop() {
 
-  if(millis()-displayTimer>1000){
+  if (millis() - displayTimer > 1000) {
     displayTimer = millis();
-    if(counter){
+    if (counter) {
       Serial.print("Samples per Second: ");
       Serial.println(counter * MAX_BUFFER_SIZE);
     }
@@ -89,12 +89,12 @@ void loop() {
       case '6':  channelSelection = 1;      break; //Play the audio on DAC1
       case '7':  channelSelection = 2;      break; //Play the audio on DAC0 & DAC1
       case '8':  Serial.println("OK");      break;
-      case '9':  startRecording(newWavFile,11000); break; //Start recording @11khz,8-bit,Mono
-      case '0':  stopRecording(newWavFile,11000);  break; //Stop the recording and finalize the file
+      case '9':  startRecording(newWavFile, 11000); break; //Start recording @11khz,8-bit,Mono
+      case '0':  stopRecording(newWavFile, 11000);  break; //Stop the recording and finalize the file
       case 'p':  playAudio(newWavFile);      break; //Play back the recorded audio
       case 'D':  SD.remove(newWavFile);      break; //Delete the file and start fresh
     }
-  }  
+  }
 }
 
 /*********************************************************/

--- a/examples/SDAudio/SdAudioRecording/myRecording.h
+++ b/examples/SDAudio/SdAudioRecording/myRecording.h
@@ -4,62 +4,62 @@
 
 /* WAV HEADER STRUCTURE */
 struct wavStruct {
- const char chunkID[4] = {'R','I','F','F'};
- uint32_t chunkSize = 36;                     //Size of (entire file in bytes - 8 bytes) or (data size + 36)
- const char format[4] = {'W','A','V','E'};
- const char subchunkID[4] = {'f','m','t',' '};
- const uint32_t subchunkSize = 16;
- const uint16_t audioFormat = 1;              //PCM == 1
- uint16_t numChannels = 1;                    //1=Mono, 2=Stereo
- uint32_t sampleRate = 11000;        
- uint32_t byteRate = 11000;                   //== SampleRate * NumChannels * BitsPerSample/8
- uint16_t blockAlign = 1;                     //== NumChannels * BitsPerSample/8
- uint16_t bitsPerSample = 8;                  //8,16,32...
- const char subChunk2ID[4]= {'d','a','t','a'};
- uint32_t subChunk2Size = 0;                  //== NumSamples * NumChannels * BitsPerSample/8
- //Data                                       //The audio data
+  const char chunkID[4] = {'R', 'I', 'F', 'F'};
+  uint32_t chunkSize = 36;                     //Size of (entire file in bytes - 8 bytes) or (data size + 36)
+  const char format[4] = {'W', 'A', 'V', 'E'};
+  const char subchunkID[4] = {'f', 'm', 't', ' '};
+  const uint32_t subchunkSize = 16;
+  const uint16_t audioFormat = 1;              //PCM == 1
+  uint16_t numChannels = 1;                    //1=Mono, 2=Stereo
+  uint32_t sampleRate = 11000;
+  uint32_t byteRate = 11000;                   //== SampleRate * NumChannels * BitsPerSample/8
+  uint16_t blockAlign = 1;                     //== NumChannels * BitsPerSample/8
+  uint16_t bitsPerSample = 8;                  //8,16,32...
+  const char subChunk2ID[4] = {'d', 'a', 't', 'a'};
+  uint32_t subChunk2Size = 0;                  //== NumSamples * NumChannels * BitsPerSample/8
+  //Data                                       //The audio data
 };
 
 /*********************************************************/
 uint32_t counter = 0;
 /*********************************************************/
 
-void ADC_Handler(void){                                    //ADC Interrupt triggered by ADC sampling completion
+void ADC_Handler(void) {                                   //ADC Interrupt triggered by ADC sampling completion
   aaAudio.getADC();
-  if(recFile){
-    recFile.write(aaAudio.adcBuffer,MAX_BUFFER_SIZE);      //Write the data to SD as it is available
+  if (recFile) {
+    recFile.write(aaAudio.adcBuffer, MAX_BUFFER_SIZE);     //Write the data to SD as it is available
     counter++;
-  }  
+  }
 }
 
 /*********************************************************/
 
-void startRecording(const char *fileName, uint32_t sampleRate){
+void startRecording(const char *fileName, uint32_t sampleRate) {
 
-  #if defined (RECORD_DEBUG)
-    Serial.print("Start Recording: ");
-    Serial.println(fileName);
-  #endif
+#if defined (RECORD_DEBUG)
+  Serial.print("Start Recording: ");
+  Serial.println(fileName);
+#endif
 
-  if(recFile){
+  if (recFile) {
     aaAudio.adcInterrupts(false);
     recFile.close();
   }
   if (myFile) {                                   //Close any open playback files & disable the DAC
     aaAudio.disableDAC();
-    myFile.close();    
+    myFile.close();
   }
-  recFile = SD.open(fileName,FILE_WRITE);         //Open the file for writing
+  recFile = SD.open(fileName, FILE_WRITE);        //Open the file for writing
 
-  if(!recFile){
-    #if defined (RECORD_DEBUG)
-      Serial.println("Failed to open file");
-    #endif
+  if (!recFile) {
+#if defined (RECORD_DEBUG)
+    Serial.println("Failed to open file");
+#endif
     return;
   }
   recFile.seek(0);                                //Write a blank WAV header
   uint8_t bb = 0;
-  for(int i=0; i<44; i++){
+  for (int i = 0; i < 44; i++) {
     recFile.write(bb);
   }
 
@@ -69,32 +69,32 @@ void startRecording(const char *fileName, uint32_t sampleRate){
   aaAudio.getADC();
   aaAudio.getADC();
   aaAudio.adcInterrupts(true);
-  
-  
+
+
 }
 
 /*********************************************************/
 
-void createWavHeader(const char *fileName, uint32_t sampleRate ){
+void createWavHeader(const char *fileName, uint32_t sampleRate ) {
 
-  if(!SD.exists(fileName)){
-    #if defined (RECORD_DEBUG)
-      Serial.println("File does not exist, please write WAV/PCM data starting at byte 44");
-    #endif
+  if (!SD.exists(fileName)) {
+#if defined (RECORD_DEBUG)
+    Serial.println("File does not exist, please write WAV/PCM data starting at byte 44");
+#endif
     return;
   }
-  recFile = SD.open(fileName,FILE_WRITE);
-  
-  if(recFile.size() <= 44){
-    #if defined (RECORD_DEBUG)
-      Serial.println("File contains no data, exiting");
-    #endif
+  recFile = SD.open(fileName, FILE_WRITE);
+
+  if (recFile.size() <= 44) {
+#if defined (RECORD_DEBUG)
+    Serial.println("File contains no data, exiting");
+#endif
     recFile.close();
     return;
   }
-  
+
   wavStruct wavHeader;
-  wavHeader.chunkSize = recFile.size()-8;
+  wavHeader.chunkSize = recFile.size() - 8;
   //wavHeader.numChannels = numChannels;
   wavHeader.sampleRate = sampleRate;
   wavHeader.byteRate = sampleRate * wavHeader.numChannels * wavHeader.bitsPerSample / 8;
@@ -102,32 +102,32 @@ void createWavHeader(const char *fileName, uint32_t sampleRate ){
   //wavHeader.bitsPerSample = bitsPerSample;
   wavHeader.subChunk2Size = recFile.size() - 44;
 
-  #if defined (RECORD_DEBUG)
+#if defined (RECORD_DEBUG)
   Serial.print("WAV Header Write ");
-  #endif
-  
+#endif
+
   recFile.seek(0);
-  if( recFile.write((byte*)&wavHeader,44) > 0){
-    #if defined (RECORD_DEBUG)    
-      Serial.println("OK");
-  }else{
-      Serial.println("Failed");
-    #endif
+  if ( recFile.write((byte*)&wavHeader, 44) > 0) {
+#if defined (RECORD_DEBUG)
+    Serial.println("OK");
+  } else {
+    Serial.println("Failed");
+#endif
   }
   recFile.close();
-  
+
 }
 
 /*********************************************************/
 
-void stopRecording(const char *fileName, uint32_t sampleRate){
+void stopRecording(const char *fileName, uint32_t sampleRate) {
 
   aaAudio.adcInterrupts(false);                        //Disable the ADC interrupt
   recFile.close();                                         //Close the file
-  createWavHeader(fileName,sampleRate);                    //Add appropriate header info, to make it a valid *.wav file
-  #if defined (RECORD_DEBUG)
-    Serial.println("Recording Stopped");
-  #endif
+  createWavHeader(fileName, sampleRate);                   //Add appropriate header info, to make it a valid *.wav file
+#if defined (RECORD_DEBUG)
+  Serial.println("Recording Stopped");
+#endif
 }
 
 /*********************************************************/

--- a/examples/SDAudio/SdAudioRecording/myWAV.h
+++ b/examples/SDAudio/SdAudioRecording/myWAV.h
@@ -26,17 +26,17 @@ void playAudio(const char *audioFile) {
     aaAudio.adcInterrupts(false);
     recFile.close();
   }
-  
+
   if (myFile) {
     aaAudio.disableDAC();
     myFile.close();
     //delay(25);
   }
-  
-  
+
+
   //Open the designated file
   myFile = SD.open(audioFile);
-  
+
   if (myFile) {
     myFile.seek(22);
     myFile.read((byte*)&numChannels, 2);
@@ -47,55 +47,54 @@ void playAudio(const char *audioFile) {
     myFile.read((byte*)&dataSize, 4);
     dataSize += 44; //Set this variable to the total size of header + data
 
-    #if defined (AUDIO_DEBUG)
-      Serial.print("\nNow Playing ");
-      Serial.println(audioFile);
-      Serial.print("Channels ");
-      Serial.print(numChannels);
-      Serial.print(", SampleRate ");
-      Serial.print(sampleRate);
-      Serial.print(", BitsPerSample ");
-      Serial.println(bitsPerSample);      
-    #endif
+#if defined (AUDIO_DEBUG)
+    Serial.print("\nNow Playing ");
+    Serial.println(audioFile);
+    Serial.print("Channels ");
+    Serial.print(numChannels);
+    Serial.print(", SampleRate ");
+    Serial.print(sampleRate);
+    Serial.print(", BitsPerSample ");
+    Serial.println(bitsPerSample);
+#endif
 
-    if(myFile.size() > dataSize){
+    if (myFile.size() > dataSize) {
       startPosition = myFile.size() - dataSize;
-      #if defined (AUDIO_DEBUG)
-        Serial.println("Skipping metadata");
-      #endif 
+#if defined (AUDIO_DEBUG)
+      Serial.println("Skipping metadata");
+#endif
     }
 
-    if(bitsPerSample > 10 ){
-       bitsPerSample = 12;
-    }else
-    if(bitsPerSample > 8){
-       bitsPerSample = 10;
-    }else{
-       bitsPerSample = 8;
+    if (bitsPerSample > 10 ) {
+      bitsPerSample = 12;
+    } else if (bitsPerSample > 8) {
+      bitsPerSample = 10;
+    } else {
+      bitsPerSample = 8;
     }
 
     sampleRate *= numChannels;
     aaAudio.dacBitsPerSample = bitsPerSample;
     aaAudio.setSampleRate(sampleRate);
 
-   #if defined (AUDIO_DEBUG)
-      Serial.print("Timer Rate ");
-      Serial.print(sampleRate);
-      Serial.print(", DAC Bits Per Sample ");
-      Serial.println(bitsPerSample); 
-    #endif
-    
+#if defined (AUDIO_DEBUG)
+    Serial.print("Timer Rate ");
+    Serial.print(sampleRate);
+    Serial.print(", DAC Bits Per Sample ");
+    Serial.println(bitsPerSample);
+#endif
+
     //Skip past the WAV header
     myFile.seek(startPosition);
     //Load one buffer
     loadBuffer();
     //Feed the DAC to start playback
     aaAudio.feedDAC();
-  }else{
-    #if defined (AUDIO_DEBUG)
-      Serial.print("Failed to open ");
-      Serial.println(audioFile);
-    #endif
+  } else {
+#if defined (AUDIO_DEBUG)
+    Serial.print("Failed to open ");
+    Serial.println(audioFile);
+#endif
   }
 }
 
@@ -103,13 +102,13 @@ void playAudio(const char *audioFile) {
 /* Function called from DAC interrupt after dacHandler(). Loads data into the dacBuffer */
 
 void loadBuffer() {
-  
+
   if (myFile) {
     if (myFile.available()) {
       if (aaAudio.dacBitsPerSample == 8) {
         //Load 32 samples into the 8-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer, MAX_BUFFER_SIZE);
-      }else{
+      } else {
         //Load 32 samples (64 bytes) into the 16-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer16, MAX_BUFFER_SIZE * 2);
         //Convert the 16-bit samples to 12-bit
@@ -117,10 +116,10 @@ void loadBuffer() {
           aaAudio.dacBuffer16[i] = (aaAudio.dacBuffer16[i] + 0x8000) >> 4;
         }
       }
-    }else{
-      #if defined (AUDIO_DEBUG)
-        Serial.println("File close");
-      #endif
+    } else {
+#if defined (AUDIO_DEBUG)
+      Serial.println("File close");
+#endif
       myFile.close();
       aaAudio.disableDAC();
     }

--- a/examples/SDAudio/SdAudioWavPlayer/SdAudioWavPlayer.ino
+++ b/examples/SDAudio/SdAudioWavPlayer/SdAudioWavPlayer.ino
@@ -25,7 +25,7 @@
   This example demonstrates a more complex method of playing *.wav files using AAAudio using interrupts to load the data
   while other code is able to run.
   Wav files in this example need to be 8 to 12-bit, 16-44khz, Mono or Stereo
-  
+
 */
 
 /******** User Config ************************************/
@@ -45,18 +45,18 @@ File myFile;
 /*********************************************************/
 
 void setup() {
-  
+
   Serial.begin(115200);
-  
+
   if (!SD.begin(SD_CS_PIN)) {
     Serial.println("SD init failed!");
     return;
   }
   Serial.println("SD ok\nAnalog Audio Begin");
-  
+
   aaAudio.begin(0, 1);     // Start AAAudio with only the DAC
   aaAudio.autoAdjust = 0;  // Disable automatic timer adjustment
-  
+
 }
 
 /*********************************************************/

--- a/examples/SDAudio/SdAudioWavPlayer/myWAV.h
+++ b/examples/SDAudio/SdAudioWavPlayer/myWAV.h
@@ -21,17 +21,17 @@ void playAudio(char *audioFile) {
   uint16_t bitsPerSample = 8;
   uint32_t dataSize = 0;
   uint32_t startPosition = 44;
-  
+
   if (myFile) {
     aaAudio.disableDAC();
     myFile.close();
     //delay(25);
   }
-  
-  
+
+
   //Open the designated file
   myFile = SD.open(audioFile);
-  
+
   if (myFile) {
     myFile.seek(22);
     myFile.read((byte*)&numChannels, 2);
@@ -42,53 +42,52 @@ void playAudio(char *audioFile) {
     myFile.read((byte*)&dataSize, 4);
     dataSize += 44; //Set this variable to the total size of header + data
 
-    #if defined (AUDIO_DEBUG)
-      Serial.print("\nNow Playing ");
-      Serial.println(audioFile);
-      Serial.print("Channels ");
-      Serial.print(numChannels);
-      Serial.print(", SampleRate ");
-      Serial.print(sampleRate);
-      Serial.print(", BitsPerSample ");
-      Serial.println(bitsPerSample);      
-    #endif
+#if defined (AUDIO_DEBUG)
+    Serial.print("\nNow Playing ");
+    Serial.println(audioFile);
+    Serial.print("Channels ");
+    Serial.print(numChannels);
+    Serial.print(", SampleRate ");
+    Serial.print(sampleRate);
+    Serial.print(", BitsPerSample ");
+    Serial.println(bitsPerSample);
+#endif
 
-    if(myFile.size() > dataSize){
+    if (myFile.size() > dataSize) {
       startPosition = myFile.size() - dataSize;
-      Serial.println("Skipping metadata");      
+      Serial.println("Skipping metadata");
     }
 
-    if(bitsPerSample > 10 ){
-       bitsPerSample = 12;
-    }else
-    if(bitsPerSample > 8){
-       bitsPerSample = 10;
-    }else{
-       bitsPerSample = 8;
+    if (bitsPerSample > 10 ) {
+      bitsPerSample = 12;
+    } else if (bitsPerSample > 8) {
+      bitsPerSample = 10;
+    } else {
+      bitsPerSample = 8;
     }
 
     sampleRate *= numChannels;
     aaAudio.dacBitsPerSample = bitsPerSample;
     aaAudio.setSampleRate(sampleRate);
 
-   #if defined (AUDIO_DEBUG)
-      Serial.print("Timer Rate ");
-      Serial.print(sampleRate);
-      Serial.print(", DAC Bits Per Sample ");
-      Serial.println(bitsPerSample); 
-    #endif
-    
+#if defined (AUDIO_DEBUG)
+    Serial.print("Timer Rate ");
+    Serial.print(sampleRate);
+    Serial.print(", DAC Bits Per Sample ");
+    Serial.println(bitsPerSample);
+#endif
+
     //Skip past the WAV header
     myFile.seek(startPosition);
     //Load one buffer
     loadBuffer();
     //Feed the DAC to start playback
     aaAudio.feedDAC();
-  }else{
-    #if defined (AUDIO_DEBUG)
-      Serial.print("Failed to open ");
-      Serial.println(audioFile);
-    #endif
+  } else {
+#if defined (AUDIO_DEBUG)
+    Serial.print("Failed to open ");
+    Serial.println(audioFile);
+#endif
   }
 }
 
@@ -96,13 +95,13 @@ void playAudio(char *audioFile) {
 /* Function called from DAC interrupt after dacHandler(). Loads data into the dacBuffer */
 
 void loadBuffer() {
-  
+
   if (myFile) {
     if (myFile.available()) {
       if (aaAudio.dacBitsPerSample == 8) {
         //Load 32 samples into the 8-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer, MAX_BUFFER_SIZE);
-      }else{
+      } else {
         //Load 32 samples (64 bytes) into the 16-bit dacBuffer
         myFile.read((byte*)aaAudio.dacBuffer16, MAX_BUFFER_SIZE * 2);
         //Convert the 16-bit samples to 12-bit
@@ -110,10 +109,10 @@ void loadBuffer() {
           aaAudio.dacBuffer16[i] = (aaAudio.dacBuffer16[i] + 0x8000) >> 4;
         }
       }
-    }else{
-      #if defined (AUDIO_DEBUG)
-        Serial.println("File close");
-      #endif
+    } else {
+#if defined (AUDIO_DEBUG)
+      Serial.println("File close");
+#endif
       myFile.close();
       aaAudio.disableDAC();
     }

--- a/examples/SimpleAdcStream/SimpleAdcStream.ino
+++ b/examples/SimpleAdcStream/SimpleAdcStream.ino
@@ -45,19 +45,19 @@ AutoAnalog aaAudio;
 
 void setup() {
 
-  pinMode(A3,OUTPUT);
-  digitalWrite(A3,HIGH);
+  pinMode(A3, OUTPUT);
+  digitalWrite(A3, HIGH);
 
   Serial.begin(115200);
   Serial.println("Analog Audio Begin");
 
-  aaAudio.begin(1,0);               //Setup aaAudio using ADC only
+  aaAudio.begin(1, 0);              //Setup aaAudio using ADC only
   aaAudio.autoAdjust = 0;           //Disable auto adjust of timers
   aaAudio.adcBitsPerSample = 12;    //Sample at 12-bits
   aaAudio.setSampleRate(32);        //Get 32 samples every second
 
   //Start loading ADC buffers
-  aaAudio.getADC(32);  
+  aaAudio.getADC(32);
 }
 
 /*********************************************************/
@@ -67,21 +67,21 @@ void loop() {
   // Get 32 samples from the ADC at the sample rate defined above
   // Note: This function only blocks if the ADC is currently sampling and autoAdjust is set to 0
   // As long as any additional code completes before the ADC is finished sampling, a continuous stream of ADC data
-  // at the defined sample rate will be available 
+  // at the defined sample rate will be available
   aaAudio.getADC(32);
 
   // Sum all the samples into a float
   float allSamples = 0.0;
-  for(int i=0; i<32; i++){
-    allSamples += aaAudio.adcBuffer16[i];    
+  for (int i = 0; i < 32; i++) {
+    allSamples += aaAudio.adcBuffer16[i];
   }
 
   // Divide the total by the number of samples
-  allSamples /= 32.0;  
+  allSamples /= 32.0;
 
   // This will print every second at a sample rate of 32 samples/second
   Serial.print("Samples Total Value / Number of Samples == ");
-  Serial.println(allSamples);  
+  Serial.println(allSamples);
 
 }
 

--- a/examples/SimpleSine/SimpleSine.ino
+++ b/examples/SimpleSine/SimpleSine.ino
@@ -30,7 +30,7 @@
 
 AutoAnalog aaAudio;
 
-void DACC_Handler(void){
+void DACC_Handler(void) {
   aaAudio.dacHandler();   //Link the DAC ISR/IRQ to the library. Called by the MCU when DAC is ready for data
 }
 
@@ -43,7 +43,7 @@ void setup() {
   //Optional: Setup the radio to broadcast the generated audio
   //setupRadio();
 
-  aaAudio.begin(0,1);           //Setup aaAudio using DAC
+  aaAudio.begin(0, 1);          //Setup aaAudio using DAC
   aaAudio.autoAdjust = 0;       //Disable automatic timer adjustment
   aaAudio.setSampleRate(16050); //Set the sample rate to 16khz
   arraysetup();                 //Load the DAC buffer using a 32-step sine wave
@@ -60,16 +60,16 @@ void loop() {
   //AutoAdjust is disabled above, so this function will block until the DAC is ready for more data
   //All other processing needs to be completed before the DAC is out of data
   //In this example, the DAC is being fed data in chunks of 32 bytes or 32 8-bit samples
-  aaAudio.feedDAC(0,32);
+  aaAudio.feedDAC(0, 32);
 
   //Optional: Broadcast the audio over radio
   //radio.startFastWrite(&aaAudio.dacBuffer,32, 1);
 
   //Choose between two different frequencies via Serial command
   //Adjust the volume by sending a '+' or '-' over Serial
-  if(Serial.available()){
+  if (Serial.available()) {
     char d = Serial.read();
-    switch(d){
+    switch (d) {
       case '1': arraysetup(); break;
       case '2': arraysetup2(); break;
       case '+': shiftVal > 0 ? --shiftVal : NULL; break;
@@ -77,7 +77,7 @@ void loop() {
       default: arraysetup(); break;
     }
     Serial.print("Volume: ");
-    Serial.print(7-shiftVal,DEC);
+    Serial.print(7 - shiftVal, DEC);
     Serial.println("/7");
   }
 }
@@ -85,74 +85,74 @@ void loop() {
 
 //Load a 32-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup(void){
-  aaAudio.dacBuffer[0]=127 >> shiftVal;
-  aaAudio.dacBuffer[1]=152 >> shiftVal;
-  aaAudio.dacBuffer[2]=176 >> shiftVal;
-  aaAudio.dacBuffer[3]=198 >> shiftVal;
-  aaAudio.dacBuffer[4]=217 >> shiftVal;
-  aaAudio.dacBuffer[5]=233 >> shiftVal;
-  aaAudio.dacBuffer[6]=245 >> shiftVal;
-  aaAudio.dacBuffer[7]=252 >> shiftVal;
-  aaAudio.dacBuffer[8]=254 >> shiftVal;
-  aaAudio.dacBuffer[9]=252 >> shiftVal;
-  aaAudio.dacBuffer[10]=245 >> shiftVal;
-  aaAudio.dacBuffer[11]=233 >> shiftVal;
-  aaAudio.dacBuffer[12]=217 >> shiftVal;
-  aaAudio.dacBuffer[13]=198 >> shiftVal;
-  aaAudio.dacBuffer[14]=176 >> shiftVal;
-  aaAudio.dacBuffer[15]=152 >> shiftVal;
-  aaAudio.dacBuffer[16]=128 >> shiftVal;
-  aaAudio.dacBuffer[17]=103 >> shiftVal;
-  aaAudio.dacBuffer[18]=79 >> shiftVal;
-  aaAudio.dacBuffer[19]=57 >> shiftVal;
-  aaAudio.dacBuffer[20]=38 >> shiftVal;
-  aaAudio.dacBuffer[21]=22 >> shiftVal;
-  aaAudio.dacBuffer[22]=10 >> shiftVal;
-  aaAudio.dacBuffer[23]=3 >> shiftVal;
-  aaAudio.dacBuffer[24]=0 >> shiftVal;
-  aaAudio.dacBuffer[25]=3 >> shiftVal;
-  aaAudio.dacBuffer[26]=10 >> shiftVal;
-  aaAudio.dacBuffer[27]=22 >> shiftVal;
-  aaAudio.dacBuffer[28]=38 >> shiftVal;
-  aaAudio.dacBuffer[29]=57 >> shiftVal;
-  aaAudio.dacBuffer[30]=79 >> shiftVal;
-  aaAudio.dacBuffer[31]=103 >> shiftVal;
+void arraysetup(void) {
+  aaAudio.dacBuffer[0] = 127 >> shiftVal;
+  aaAudio.dacBuffer[1] = 152 >> shiftVal;
+  aaAudio.dacBuffer[2] = 176 >> shiftVal;
+  aaAudio.dacBuffer[3] = 198 >> shiftVal;
+  aaAudio.dacBuffer[4] = 217 >> shiftVal;
+  aaAudio.dacBuffer[5] = 233 >> shiftVal;
+  aaAudio.dacBuffer[6] = 245 >> shiftVal;
+  aaAudio.dacBuffer[7] = 252 >> shiftVal;
+  aaAudio.dacBuffer[8] = 254 >> shiftVal;
+  aaAudio.dacBuffer[9] = 252 >> shiftVal;
+  aaAudio.dacBuffer[10] = 245 >> shiftVal;
+  aaAudio.dacBuffer[11] = 233 >> shiftVal;
+  aaAudio.dacBuffer[12] = 217 >> shiftVal;
+  aaAudio.dacBuffer[13] = 198 >> shiftVal;
+  aaAudio.dacBuffer[14] = 176 >> shiftVal;
+  aaAudio.dacBuffer[15] = 152 >> shiftVal;
+  aaAudio.dacBuffer[16] = 128 >> shiftVal;
+  aaAudio.dacBuffer[17] = 103 >> shiftVal;
+  aaAudio.dacBuffer[18] = 79 >> shiftVal;
+  aaAudio.dacBuffer[19] = 57 >> shiftVal;
+  aaAudio.dacBuffer[20] = 38 >> shiftVal;
+  aaAudio.dacBuffer[21] = 22 >> shiftVal;
+  aaAudio.dacBuffer[22] = 10 >> shiftVal;
+  aaAudio.dacBuffer[23] = 3 >> shiftVal;
+  aaAudio.dacBuffer[24] = 0 >> shiftVal;
+  aaAudio.dacBuffer[25] = 3 >> shiftVal;
+  aaAudio.dacBuffer[26] = 10 >> shiftVal;
+  aaAudio.dacBuffer[27] = 22 >> shiftVal;
+  aaAudio.dacBuffer[28] = 38 >> shiftVal;
+  aaAudio.dacBuffer[29] = 57 >> shiftVal;
+  aaAudio.dacBuffer[30] = 79 >> shiftVal;
+  aaAudio.dacBuffer[31] = 103 >> shiftVal;
 }
 
 //Load a 16-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup2(void){
-  aaAudio.dacBuffer[0]=127 >> shiftVal;
-  aaAudio.dacBuffer[1]=176 >> shiftVal;
-  aaAudio.dacBuffer[2]=217 >> shiftVal;
-  aaAudio.dacBuffer[3]=245 >> shiftVal;
-  aaAudio.dacBuffer[4]=254 >> shiftVal;
-  aaAudio.dacBuffer[5]=245 >> shiftVal;
-  aaAudio.dacBuffer[6]=217 >> shiftVal;
-  aaAudio.dacBuffer[7]=176 >> shiftVal;
-  aaAudio.dacBuffer[8]=128 >> shiftVal;
-  aaAudio.dacBuffer[9]=79 >> shiftVal;
-  aaAudio.dacBuffer[10]=38 >> shiftVal;
-  aaAudio.dacBuffer[11]=10 >> shiftVal;
-  aaAudio.dacBuffer[12]=0 >> shiftVal;
-  aaAudio.dacBuffer[13]=10 >> shiftVal;
-  aaAudio.dacBuffer[14]=38 >> shiftVal;
-  aaAudio.dacBuffer[15]=79 >> shiftVal;
-  aaAudio.dacBuffer[16]=127 >> shiftVal;
-  aaAudio.dacBuffer[17]=176 >> shiftVal;
-  aaAudio.dacBuffer[18]=217 >> shiftVal;
-  aaAudio.dacBuffer[19]=245 >> shiftVal;
-  aaAudio.dacBuffer[20]=254 >> shiftVal;
-  aaAudio.dacBuffer[21]=245 >> shiftVal;
-  aaAudio.dacBuffer[22]=217 >> shiftVal;
-  aaAudio.dacBuffer[23]=176 >> shiftVal;
-  aaAudio.dacBuffer[24]=128 >> shiftVal;
-  aaAudio.dacBuffer[25]=79 >> shiftVal;
-  aaAudio.dacBuffer[26]=38 >> shiftVal;
-  aaAudio.dacBuffer[27]=10 >> shiftVal;
-  aaAudio.dacBuffer[28]=0 >> shiftVal;
-  aaAudio.dacBuffer[29]=10 >> shiftVal;
-  aaAudio.dacBuffer[30]=38 >> shiftVal;
-  aaAudio.dacBuffer[31]=79 >> shiftVal;
+void arraysetup2(void) {
+  aaAudio.dacBuffer[0] = 127 >> shiftVal;
+  aaAudio.dacBuffer[1] = 176 >> shiftVal;
+  aaAudio.dacBuffer[2] = 217 >> shiftVal;
+  aaAudio.dacBuffer[3] = 245 >> shiftVal;
+  aaAudio.dacBuffer[4] = 254 >> shiftVal;
+  aaAudio.dacBuffer[5] = 245 >> shiftVal;
+  aaAudio.dacBuffer[6] = 217 >> shiftVal;
+  aaAudio.dacBuffer[7] = 176 >> shiftVal;
+  aaAudio.dacBuffer[8] = 128 >> shiftVal;
+  aaAudio.dacBuffer[9] = 79 >> shiftVal;
+  aaAudio.dacBuffer[10] = 38 >> shiftVal;
+  aaAudio.dacBuffer[11] = 10 >> shiftVal;
+  aaAudio.dacBuffer[12] = 0 >> shiftVal;
+  aaAudio.dacBuffer[13] = 10 >> shiftVal;
+  aaAudio.dacBuffer[14] = 38 >> shiftVal;
+  aaAudio.dacBuffer[15] = 79 >> shiftVal;
+  aaAudio.dacBuffer[16] = 127 >> shiftVal;
+  aaAudio.dacBuffer[17] = 176 >> shiftVal;
+  aaAudio.dacBuffer[18] = 217 >> shiftVal;
+  aaAudio.dacBuffer[19] = 245 >> shiftVal;
+  aaAudio.dacBuffer[20] = 254 >> shiftVal;
+  aaAudio.dacBuffer[21] = 245 >> shiftVal;
+  aaAudio.dacBuffer[22] = 217 >> shiftVal;
+  aaAudio.dacBuffer[23] = 176 >> shiftVal;
+  aaAudio.dacBuffer[24] = 128 >> shiftVal;
+  aaAudio.dacBuffer[25] = 79 >> shiftVal;
+  aaAudio.dacBuffer[26] = 38 >> shiftVal;
+  aaAudio.dacBuffer[27] = 10 >> shiftVal;
+  aaAudio.dacBuffer[28] = 0 >> shiftVal;
+  aaAudio.dacBuffer[29] = 10 >> shiftVal;
+  aaAudio.dacBuffer[30] = 38 >> shiftVal;
+  aaAudio.dacBuffer[31] = 79 >> shiftVal;
 }

--- a/examples/SimpleSine/SimpleSine.ino
+++ b/examples/SimpleSine/SimpleSine.ino
@@ -16,33 +16,33 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-* 
+*
 * SineWave Example:
 * Simple generation of a sine wave & optionally broadcasting the audio via radio
 * Send a number 1 or 2 over Serial to change frequency, +/- to adjust volume
-* 
+*
 */
 
- 
+
 #include <AutoAnalogAudio.h>
 //#include <RF24.h>
 //#include "myRadio.h"
 
 AutoAnalog aaAudio;
 
-void DACC_Handler(void){ 
+void DACC_Handler(void){
   aaAudio.dacHandler();   //Link the DAC ISR/IRQ to the library. Called by the MCU when DAC is ready for data
 }
 
 
 void setup() {
-  
+
   Serial.begin(115200);
   Serial.println("Analog Audio Begin");
-  
+
   //Optional: Setup the radio to broadcast the generated audio
   //setupRadio();
-  
+
   aaAudio.begin(0,1);           //Setup aaAudio using DAC
   aaAudio.autoAdjust = 0;       //Disable automatic timer adjustment
   aaAudio.setSampleRate(16050); //Set the sample rate to 16khz
@@ -63,8 +63,8 @@ void loop() {
   aaAudio.feedDAC(0,32);
 
   //Optional: Broadcast the audio over radio
-  //radio.startFastWrite(&aaAudio.dacBuffer,32,1);
-  
+  //radio.startFastWrite(&aaAudio.dacBuffer,32, 1);
+
   //Choose between two different frequencies via Serial command
   //Adjust the volume by sending a '+' or '-' over Serial
   if(Serial.available()){
@@ -79,80 +79,80 @@ void loop() {
     Serial.print("Volume: ");
     Serial.print(7-shiftVal,DEC);
     Serial.println("/7");
-  }  
+  }
 }
 
 
 //Load a 32-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup(void){ 
-  aaAudio.dacBuffer[0]=127 >> shiftVal; 
-  aaAudio.dacBuffer[1]=152 >> shiftVal; 
-  aaAudio.dacBuffer[2]=176 >> shiftVal; 
-  aaAudio.dacBuffer[3]=198 >> shiftVal; 
-  aaAudio.dacBuffer[4]=217 >> shiftVal; 
-  aaAudio.dacBuffer[5]=233 >> shiftVal; 
-  aaAudio.dacBuffer[6]=245 >> shiftVal; 
-  aaAudio.dacBuffer[7]=252 >> shiftVal; 
-  aaAudio.dacBuffer[8]=254 >> shiftVal; 
-  aaAudio.dacBuffer[9]=252 >> shiftVal; 
-  aaAudio.dacBuffer[10]=245 >> shiftVal; 
-  aaAudio.dacBuffer[11]=233 >> shiftVal; 
-  aaAudio.dacBuffer[12]=217 >> shiftVal; 
-  aaAudio.dacBuffer[13]=198 >> shiftVal; 
-  aaAudio.dacBuffer[14]=176 >> shiftVal; 
-  aaAudio.dacBuffer[15]=152 >> shiftVal; 
-  aaAudio.dacBuffer[16]=128 >> shiftVal; 
-  aaAudio.dacBuffer[17]=103 >> shiftVal; 
-  aaAudio.dacBuffer[18]=79 >> shiftVal; 
-  aaAudio.dacBuffer[19]=57 >> shiftVal; 
-  aaAudio.dacBuffer[20]=38 >> shiftVal; 
-  aaAudio.dacBuffer[21]=22 >> shiftVal; 
-  aaAudio.dacBuffer[22]=10 >> shiftVal; 
-  aaAudio.dacBuffer[23]=3 >> shiftVal; 
-  aaAudio.dacBuffer[24]=0 >> shiftVal; 
-  aaAudio.dacBuffer[25]=3 >> shiftVal; 
-  aaAudio.dacBuffer[26]=10 >> shiftVal; 
-  aaAudio.dacBuffer[27]=22 >> shiftVal; 
-  aaAudio.dacBuffer[28]=38 >> shiftVal; 
-  aaAudio.dacBuffer[29]=57 >> shiftVal; 
-  aaAudio.dacBuffer[30]=79 >> shiftVal; 
-  aaAudio.dacBuffer[31]=103 >> shiftVal; 
+void arraysetup(void){
+  aaAudio.dacBuffer[0]=127 >> shiftVal;
+  aaAudio.dacBuffer[1]=152 >> shiftVal;
+  aaAudio.dacBuffer[2]=176 >> shiftVal;
+  aaAudio.dacBuffer[3]=198 >> shiftVal;
+  aaAudio.dacBuffer[4]=217 >> shiftVal;
+  aaAudio.dacBuffer[5]=233 >> shiftVal;
+  aaAudio.dacBuffer[6]=245 >> shiftVal;
+  aaAudio.dacBuffer[7]=252 >> shiftVal;
+  aaAudio.dacBuffer[8]=254 >> shiftVal;
+  aaAudio.dacBuffer[9]=252 >> shiftVal;
+  aaAudio.dacBuffer[10]=245 >> shiftVal;
+  aaAudio.dacBuffer[11]=233 >> shiftVal;
+  aaAudio.dacBuffer[12]=217 >> shiftVal;
+  aaAudio.dacBuffer[13]=198 >> shiftVal;
+  aaAudio.dacBuffer[14]=176 >> shiftVal;
+  aaAudio.dacBuffer[15]=152 >> shiftVal;
+  aaAudio.dacBuffer[16]=128 >> shiftVal;
+  aaAudio.dacBuffer[17]=103 >> shiftVal;
+  aaAudio.dacBuffer[18]=79 >> shiftVal;
+  aaAudio.dacBuffer[19]=57 >> shiftVal;
+  aaAudio.dacBuffer[20]=38 >> shiftVal;
+  aaAudio.dacBuffer[21]=22 >> shiftVal;
+  aaAudio.dacBuffer[22]=10 >> shiftVal;
+  aaAudio.dacBuffer[23]=3 >> shiftVal;
+  aaAudio.dacBuffer[24]=0 >> shiftVal;
+  aaAudio.dacBuffer[25]=3 >> shiftVal;
+  aaAudio.dacBuffer[26]=10 >> shiftVal;
+  aaAudio.dacBuffer[27]=22 >> shiftVal;
+  aaAudio.dacBuffer[28]=38 >> shiftVal;
+  aaAudio.dacBuffer[29]=57 >> shiftVal;
+  aaAudio.dacBuffer[30]=79 >> shiftVal;
+  aaAudio.dacBuffer[31]=103 >> shiftVal;
 }
 
 //Load a 16-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup2(void){ 
+void arraysetup2(void){
   aaAudio.dacBuffer[0]=127 >> shiftVal;
-  aaAudio.dacBuffer[1]=176 >> shiftVal; 
-  aaAudio.dacBuffer[2]=217 >> shiftVal; 
-  aaAudio.dacBuffer[3]=245 >> shiftVal; 
-  aaAudio.dacBuffer[4]=254 >> shiftVal; 
-  aaAudio.dacBuffer[5]=245 >> shiftVal; 
-  aaAudio.dacBuffer[6]=217 >> shiftVal; 
-  aaAudio.dacBuffer[7]=176 >> shiftVal; 
-  aaAudio.dacBuffer[8]=128 >> shiftVal; 
-  aaAudio.dacBuffer[9]=79 >> shiftVal; 
-  aaAudio.dacBuffer[10]=38 >> shiftVal; 
-  aaAudio.dacBuffer[11]=10 >> shiftVal; 
-  aaAudio.dacBuffer[12]=0 >> shiftVal; 
-  aaAudio.dacBuffer[13]=10 >> shiftVal; 
-  aaAudio.dacBuffer[14]=38 >> shiftVal; 
+  aaAudio.dacBuffer[1]=176 >> shiftVal;
+  aaAudio.dacBuffer[2]=217 >> shiftVal;
+  aaAudio.dacBuffer[3]=245 >> shiftVal;
+  aaAudio.dacBuffer[4]=254 >> shiftVal;
+  aaAudio.dacBuffer[5]=245 >> shiftVal;
+  aaAudio.dacBuffer[6]=217 >> shiftVal;
+  aaAudio.dacBuffer[7]=176 >> shiftVal;
+  aaAudio.dacBuffer[8]=128 >> shiftVal;
+  aaAudio.dacBuffer[9]=79 >> shiftVal;
+  aaAudio.dacBuffer[10]=38 >> shiftVal;
+  aaAudio.dacBuffer[11]=10 >> shiftVal;
+  aaAudio.dacBuffer[12]=0 >> shiftVal;
+  aaAudio.dacBuffer[13]=10 >> shiftVal;
+  aaAudio.dacBuffer[14]=38 >> shiftVal;
   aaAudio.dacBuffer[15]=79 >> shiftVal;
   aaAudio.dacBuffer[16]=127 >> shiftVal;
-  aaAudio.dacBuffer[17]=176 >> shiftVal; 
-  aaAudio.dacBuffer[18]=217 >> shiftVal; 
-  aaAudio.dacBuffer[19]=245 >> shiftVal; 
-  aaAudio.dacBuffer[20]=254 >> shiftVal; 
-  aaAudio.dacBuffer[21]=245 >> shiftVal; 
-  aaAudio.dacBuffer[22]=217 >> shiftVal; 
-  aaAudio.dacBuffer[23]=176 >> shiftVal; 
-  aaAudio.dacBuffer[24]=128 >> shiftVal; 
-  aaAudio.dacBuffer[25]=79 >> shiftVal; 
-  aaAudio.dacBuffer[26]=38 >> shiftVal; 
-  aaAudio.dacBuffer[27]=10 >> shiftVal; 
-  aaAudio.dacBuffer[28]=0 >> shiftVal; 
-  aaAudio.dacBuffer[29]=10 >> shiftVal; 
-  aaAudio.dacBuffer[30]=38 >> shiftVal; 
-  aaAudio.dacBuffer[31]=79 >> shiftVal; 
+  aaAudio.dacBuffer[17]=176 >> shiftVal;
+  aaAudio.dacBuffer[18]=217 >> shiftVal;
+  aaAudio.dacBuffer[19]=245 >> shiftVal;
+  aaAudio.dacBuffer[20]=254 >> shiftVal;
+  aaAudio.dacBuffer[21]=245 >> shiftVal;
+  aaAudio.dacBuffer[22]=217 >> shiftVal;
+  aaAudio.dacBuffer[23]=176 >> shiftVal;
+  aaAudio.dacBuffer[24]=128 >> shiftVal;
+  aaAudio.dacBuffer[25]=79 >> shiftVal;
+  aaAudio.dacBuffer[26]=38 >> shiftVal;
+  aaAudio.dacBuffer[27]=10 >> shiftVal;
+  aaAudio.dacBuffer[28]=0 >> shiftVal;
+  aaAudio.dacBuffer[29]=10 >> shiftVal;
+  aaAudio.dacBuffer[30]=38 >> shiftVal;
+  aaAudio.dacBuffer[31]=79 >> shiftVal;
 }

--- a/examples/SimpleSine/myRadio.h
+++ b/examples/SimpleSine/myRadio.h
@@ -2,17 +2,17 @@
 
 #include <RF24.h>
 
-RF24 radio(46,52);
+RF24 radio(46, 52);
 
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL };
+const uint64_t pipes[14] = {0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL};
 
-bool tx,fail,rx;
+bool tx, fail, rx;
 uint8_t pipeNo = 0;
 
 void RX();
 
 void setupRadio(){
-  
+
   radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_MAX);
@@ -20,19 +20,19 @@ void setupRadio(){
   radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
-  radio.openReadingPipe(1,pipes[1]);
-  radio.openReadingPipe(2,pipes[2]);
-  radio.setAutoAck(2,1);
+  radio.openReadingPipe(1, pipes[1]);
+  radio.openReadingPipe(2, pipes[2]);
+  radio.setAutoAck(2, 1);
   radio.openWritingPipe(pipes[0]);
   radio.txDelay = 0;
   radio.csDelay = 0;
-  radio.maskIRQ(0,1,0);
+  radio.maskIRQ(0, 1, 0);
   radio.printDetails();
 
   //radio.startListening();
   radio.stopListening();
-  //attachInterrupt(digitalPinToInterrupt(4),RX,FALLING);
-  
+  //attachInterrupt(digitalPinToInterrupt(4), RX, FALLING);
+
 }
 
 

--- a/examples/SimpleSine/myRadio.h
+++ b/examples/SimpleSine/myRadio.h
@@ -11,7 +11,7 @@ uint8_t pipeNo = 0;
 
 void RX();
 
-void setupRadio(){
+void setupRadio() {
 
   radio.begin();
   radio.setChannel(1);

--- a/examples/SimpleSine12Bit/SimpleSine12Bit.ino
+++ b/examples/SimpleSine12Bit/SimpleSine12Bit.ino
@@ -16,32 +16,32 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-* 
+*
 * SineWave12Bit Example (Requires Arduino Due or better):
 * Simple generation of a 12-bit sine wave
 * Send a number 1 or 2 over Serial to change frequency, +/- to adjust volume
-* 
+*
 */
 
- 
+
 #include <AutoAnalogAudio.h>
 
 AutoAnalog aaAudio;
 
-void DACC_Handler(void){ 
+void DACC_Handler(void) {
   aaAudio.dacHandler();   //Link the DAC ISR/IRQ to the library. Called by the MCU when DAC is ready for data
 }
 
 
 void setup() {
-  
+
   Serial.begin(115200);
   Serial.println("Analog Audio Begin");
-  
-  aaAudio.begin(0,1);           //Setup aaAudio using DAC
+
+  aaAudio.begin(0, 1);          //Setup aaAudio using DAC
   aaAudio.autoAdjust = 0;       //Disable automatic timer adjustment
   aaAudio.setSampleRate(16000); //Set the sample rate to 16khz
-  aaAudio.dacBitsPerSample=12;  //Use 12-bit samples for the DAC
+  aaAudio.dacBitsPerSample = 12; //Use 12-bit samples for the DAC
   arraysetup();                 //Load the DAC buffer using a 32-step sine wave
 
 }
@@ -55,13 +55,13 @@ void loop() {
   //AutoAdjust is disabled above, so this function will block until the DAC is ready for more data
   //All other processing needs to be completed before the DAC is out of data
   //In this example, the DAC is being fed data in chunks of 32 bytes or 32 8-bit samples
-  aaAudio.feedDAC(0,32);
+  aaAudio.feedDAC(0, 32);
 
   //Choose between two different frequencies via Serial command
   //Adjust the volume by sending a '+' or '-' over Serial
-  if(Serial.available()){
+  if (Serial.available()) {
     char d = Serial.read();
-    switch(d){
+    switch (d) {
       case '1': arraysetup(); break;
       case '2': arraysetup2(); break;
       case '+': shiftVal > 0 ? --shiftVal : NULL; break;
@@ -69,82 +69,82 @@ void loop() {
       default: arraysetup(); break;
     }
     Serial.print("Volume: ");
-    Serial.print(11-shiftVal,DEC);
+    Serial.print(11 - shiftVal, DEC);
     Serial.println("/11");
-  }  
+  }
 }
 
 //Load a 32-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup(void){ 
-  aaAudio.dacBuffer16[0]=0x800 >> shiftVal; 
-  aaAudio.dacBuffer16[1]=0x990 >> shiftVal; 
-  aaAudio.dacBuffer16[2]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[3]=0xC72  >> shiftVal; 
-  aaAudio.dacBuffer16[4]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[5]=0xEA7 >> shiftVal; 
-  aaAudio.dacBuffer16[6]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[7]=0xFD9 >> shiftVal; 
-  aaAudio.dacBuffer16[8]=0xFFF >> shiftVal; 
-  aaAudio.dacBuffer16[9]=0xFD9 >> shiftVal; 
-  aaAudio.dacBuffer16[10]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[11]=0xEA7 >> shiftVal; 
-  aaAudio.dacBuffer16[12]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[13]=0xC72 >> shiftVal; 
-  aaAudio.dacBuffer16[14]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[15]=0x990 >> shiftVal; 
-  aaAudio.dacBuffer16[16]=0x800 >> shiftVal; 
-  aaAudio.dacBuffer16[17]=0x670 >> shiftVal; 
-  aaAudio.dacBuffer16[18]=0x4F0 >> shiftVal; 
-  aaAudio.dacBuffer16[19]=0x38E >> shiftVal; 
-  aaAudio.dacBuffer16[20]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[21]=0x159 >> shiftVal; 
-  aaAudio.dacBuffer16[22]=0x9C >> shiftVal; 
-  aaAudio.dacBuffer16[23]=0x27 >> shiftVal; 
-  aaAudio.dacBuffer16[24]=0x0 >> shiftVal; 
-  aaAudio.dacBuffer16[25]=0x27 >> shiftVal; 
-  aaAudio.dacBuffer16[26]=0x9c >> shiftVal; 
-  aaAudio.dacBuffer16[27]=0x159 >> shiftVal; 
-  aaAudio.dacBuffer16[28]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[29]=0x38E >> shiftVal; 
-  aaAudio.dacBuffer16[30]=0x4F0 >> shiftVal; 
-  aaAudio.dacBuffer16[31]=0x670 >> shiftVal; 
+void arraysetup(void) {
+  aaAudio.dacBuffer16[0] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[1] = 0x990 >> shiftVal;
+  aaAudio.dacBuffer16[2] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[3] = 0xC72  >> shiftVal;
+  aaAudio.dacBuffer16[4] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[5] = 0xEA7 >> shiftVal;
+  aaAudio.dacBuffer16[6] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[7] = 0xFD9 >> shiftVal;
+  aaAudio.dacBuffer16[8] = 0xFFF >> shiftVal;
+  aaAudio.dacBuffer16[9] = 0xFD9 >> shiftVal;
+  aaAudio.dacBuffer16[10] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[11] = 0xEA7 >> shiftVal;
+  aaAudio.dacBuffer16[12] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[13] = 0xC72 >> shiftVal;
+  aaAudio.dacBuffer16[14] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[15] = 0x990 >> shiftVal;
+  aaAudio.dacBuffer16[16] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[17] = 0x670 >> shiftVal;
+  aaAudio.dacBuffer16[18] = 0x4F0 >> shiftVal;
+  aaAudio.dacBuffer16[19] = 0x38E >> shiftVal;
+  aaAudio.dacBuffer16[20] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[21] = 0x159 >> shiftVal;
+  aaAudio.dacBuffer16[22] = 0x9C >> shiftVal;
+  aaAudio.dacBuffer16[23] = 0x27 >> shiftVal;
+  aaAudio.dacBuffer16[24] = 0x0 >> shiftVal;
+  aaAudio.dacBuffer16[25] = 0x27 >> shiftVal;
+  aaAudio.dacBuffer16[26] = 0x9c >> shiftVal;
+  aaAudio.dacBuffer16[27] = 0x159 >> shiftVal;
+  aaAudio.dacBuffer16[28] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[29] = 0x38E >> shiftVal;
+  aaAudio.dacBuffer16[30] = 0x4F0 >> shiftVal;
+  aaAudio.dacBuffer16[31] = 0x670 >> shiftVal;
 }
 
 
 //Load a 16-step sine wave into the dacBuffer
 //Shift the values according to volume
-void arraysetup2(void){ 
-  aaAudio.dacBuffer16[0]=0x800 >> shiftVal;
-  aaAudio.dacBuffer16[1]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[2]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[3]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[4]=0xFFF >> shiftVal; 
-  aaAudio.dacBuffer16[5]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[6]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[7]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[8]=0x800 >> shiftVal; 
-  aaAudio.dacBuffer16[9]=0x4F0 >> shiftVal; 
-  aaAudio.dacBuffer16[10]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[11]=0x9C >> shiftVal; 
-  aaAudio.dacBuffer16[12]=0x0 >> shiftVal; 
-  aaAudio.dacBuffer16[13]=0x9C >> shiftVal; 
-  aaAudio.dacBuffer16[14]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[15]=0x4F0 >> shiftVal;
-  aaAudio.dacBuffer16[16]=0x800 >> shiftVal;
-  aaAudio.dacBuffer16[17]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[18]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[19]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[20]=0x1000 >> shiftVal; 
-  aaAudio.dacBuffer16[21]=0xF64 >> shiftVal; 
-  aaAudio.dacBuffer16[22]=0xDA8 >> shiftVal; 
-  aaAudio.dacBuffer16[23]=0xB10 >> shiftVal; 
-  aaAudio.dacBuffer16[24]=0x800 >> shiftVal; 
-  aaAudio.dacBuffer16[25]=0x4F0 >> shiftVal; 
-  aaAudio.dacBuffer16[26]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[27]=0x9C >> shiftVal; 
-  aaAudio.dacBuffer16[28]=0x0 >> shiftVal; 
-  aaAudio.dacBuffer16[29]=0x9C >> shiftVal; 
-  aaAudio.dacBuffer16[30]=0x258 >> shiftVal; 
-  aaAudio.dacBuffer16[31]=0x4F0 >> shiftVal;
+void arraysetup2(void) {
+  aaAudio.dacBuffer16[0] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[1] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[2] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[3] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[4] = 0xFFF >> shiftVal;
+  aaAudio.dacBuffer16[5] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[6] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[7] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[8] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[9] = 0x4F0 >> shiftVal;
+  aaAudio.dacBuffer16[10] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[11] = 0x9C >> shiftVal;
+  aaAudio.dacBuffer16[12] = 0x0 >> shiftVal;
+  aaAudio.dacBuffer16[13] = 0x9C >> shiftVal;
+  aaAudio.dacBuffer16[14] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[15] = 0x4F0 >> shiftVal;
+  aaAudio.dacBuffer16[16] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[17] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[18] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[19] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[20] = 0x1000 >> shiftVal;
+  aaAudio.dacBuffer16[21] = 0xF64 >> shiftVal;
+  aaAudio.dacBuffer16[22] = 0xDA8 >> shiftVal;
+  aaAudio.dacBuffer16[23] = 0xB10 >> shiftVal;
+  aaAudio.dacBuffer16[24] = 0x800 >> shiftVal;
+  aaAudio.dacBuffer16[25] = 0x4F0 >> shiftVal;
+  aaAudio.dacBuffer16[26] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[27] = 0x9C >> shiftVal;
+  aaAudio.dacBuffer16[28] = 0x0 >> shiftVal;
+  aaAudio.dacBuffer16[29] = 0x9C >> shiftVal;
+  aaAudio.dacBuffer16[30] = 0x258 >> shiftVal;
+  aaAudio.dacBuffer16[31] = 0x4F0 >> shiftVal;
 }

--- a/examples/WirelessMicrophone/WirelessMicrophone.ino
+++ b/examples/WirelessMicrophone/WirelessMicrophone.ino
@@ -36,8 +36,8 @@
 
   1. This example uses the onboard ADC to sample audio/analog data via pin A0
   2. The data is then sent via radio to another device
-  3. Audio is captured in 8-bit,mono,16khz. 
-  
+  3. Audio is captured in 8-bit,mono,16khz.
+
   Library supports 8,10,12-bit sampling at various sample rates.
 
 */
@@ -61,7 +61,7 @@ void setup() {
   Serial.begin(115200);
   Serial.println("Analog Audio Begin");
 
-  aaAudio.begin(1,0);  //Setup aaAudio using ADC only
+  aaAudio.begin(1, 0); //Setup aaAudio using ADC only
   aaAudio.autoAdjust = 0;
   aaAudio.adcBitsPerSample = 8;
   aaAudio.setSampleRate(16050);
@@ -90,7 +90,7 @@ void loop() {
 
   // With autoAdjust disabled, getADC() will block until the ADC data is ready
   aaAudio.getADC(32);
-  radio.writeFast(&aaAudio.adcBuffer,32);
+  radio.writeFast(&aaAudio.adcBuffer, 32);
 }
 
 /*********************************************************/

--- a/examples/WirelessMicrophone/myRadio.h
+++ b/examples/WirelessMicrophone/myRadio.h
@@ -11,7 +11,7 @@ uint8_t pipeNo = 0;
 
 void RX();
 
-void setupRadio(){
+void setupRadio() {
 
   radio.begin();
   radio.setChannel(1);

--- a/examples/WirelessMicrophone/myRadio.h
+++ b/examples/WirelessMicrophone/myRadio.h
@@ -2,17 +2,17 @@
 
 #include <RF24.h>
 
-RF24 radio(46,52);
+RF24 radio(46, 52);
 
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL };
+const uint64_t pipes[14] = {0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL};
 
-bool tx,fail,rx;
+bool tx, fail, rx;
 uint8_t pipeNo = 0;
 
 void RX();
 
 void setupRadio(){
-  
+
   radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_LOW);
@@ -20,19 +20,19 @@ void setupRadio(){
   radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
-  radio.openReadingPipe(1,pipes[1]);
-  radio.openReadingPipe(2,pipes[2]);
-  radio.setAutoAck(2,1);
+  radio.openReadingPipe(1, pipes[1]);
+  radio.openReadingPipe(2, pipes[2]);
+  radio.setAutoAck(2, 1);
   radio.openWritingPipe(pipes[0]);
   radio.txDelay = 0;
   radio.csDelay = 0;
-  radio.maskIRQ(0,1,0);
+  radio.maskIRQ(0, 1, 0);
   radio.printDetails();
 
   radio.startListening();
   radio.stopListening();
-  //attachInterrupt(digitalPinToInterrupt(4),RX,FALLING);
-  
+  //attachInterrupt(digitalPinToInterrupt(4), RX, FALLING);
+
 }
 
 

--- a/examples/WirelessSpeaker/WirelessSpeaker.ino
+++ b/examples/WirelessSpeaker/WirelessSpeaker.ino
@@ -114,7 +114,7 @@ void RX() {
     } else {
 
       radio.read(&aaAudio.dacBuffer16, 32);                   // Read the available radio data
-      
+
       for (int i = 0; i < 16; i++) {                          //Convert signed 16-bit variables into unsigned 12-bit
         aaAudio.dacBuffer16[i] += 0x8000;
         aaAudio.dacBuffer16[i] = aaAudio.dacBuffer16[i] >> 4;

--- a/examples/WirelessSpeaker/myRadio.h
+++ b/examples/WirelessSpeaker/myRadio.h
@@ -11,7 +11,7 @@ uint8_t pipeNo = 0;
 
 void RX();
 
-void setupRadio(){
+void setupRadio() {
 
   radio.begin();
   radio.setChannel(1);

--- a/examples/WirelessSpeaker/myRadio.h
+++ b/examples/WirelessSpeaker/myRadio.h
@@ -2,17 +2,17 @@
 
 #include <RF24.h>
 
-RF24 radio(46,52);
+RF24 radio(46, 52);
 
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL };
+const uint64_t pipes[14] = {0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL};
 
-bool tx,fail,rx;
+bool tx, fail, rx;
 uint8_t pipeNo = 0;
 
 void RX();
 
 void setupRadio(){
-  
+
   radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_LOW);
@@ -20,19 +20,19 @@ void setupRadio(){
   radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
-  radio.openReadingPipe(1,pipes[1]);
-  radio.openReadingPipe(2,pipes[2]);
-  radio.setAutoAck(2,1);
+  radio.openReadingPipe(1, pipes[1]);
+  radio.openReadingPipe(2, pipes[2]);
+  radio.setAutoAck(2, 1);
   radio.openWritingPipe(pipes[0]);
   radio.txDelay = 0;
   radio.csDelay = 0;
-  radio.maskIRQ(0,1,0);
+  radio.maskIRQ(0, 1, 0);
   radio.printDetails();
 
   radio.startListening();
 
-  attachInterrupt(digitalPinToInterrupt(4),RX,FALLING);
-  
+  attachInterrupt(digitalPinToInterrupt(4), RX, FALLING);
+
 }
 
 

--- a/examples/WirelessTx_RPi/radioRelay.cpp
+++ b/examples/WirelessTx_RPi/radioRelay.cpp
@@ -23,7 +23,7 @@ using namespace std;
 
 /****************** Raspberry Pi ***********************/
 
-RF24 radio(25,0);
+RF24 radio(25, 0);
 
 // File should be 16 khz sample rate, mono, wav format
 char audioFile[] = "Guitar8b16kMono.wav";
@@ -34,13 +34,13 @@ char audioFile[] = "Guitar8b16kMono.wav";
 /**************************************************************/
 
 // The addresses used in RF24Audio
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL, 0x544d52683CLL,0x544d526846LL, 0x544d526850LL,0x544d52685ALL, 0x544d526820LL, 0x544d52686ELL, 0x544d52684BLL, 0x544d526841LL, 0x544d526855LL,0x544d52685FLL,0x544d526869LL};
+const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL, 0x544d52683CLL, 0x544d526846LL, 0x544d526850LL, 0x544d52685ALL, 0x544d526820LL, 0x544d52686ELL, 0x544d52684BLL, 0x544d526841LL, 0x544d526855LL, 0x544d52685FLL, 0x544d526869LL};
 unsigned int sz = 0;
 void intHandler();
-uint32_t reads = 0,writes = 0;
+uint32_t reads = 0, writes = 0;
 uint8_t bufR[32];
 
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
 
   cout << "RF24Audio On Rpi\n";
 
@@ -71,92 +71,92 @@ int main(int argc, char** argv){
   streampos size;
   char * memblock;
 
-  ifstream file (audioFile, ios::in|ios::binary|ios::ate);
-  if (file.is_open()){
+  ifstream file (audioFile, ios::in | ios::binary | ios::ate);
+  if (file.is_open()) {
 
     size = file.tellg();//file.tellg();
     sz = file.tellg();
-    printf("%d\n",sz);
+    printf("%d\n", sz);
     memblock = new char [sz];
     file.seekg (0, ios::beg);
     file.read (memblock, sz);
     file.close();
     cout << "the entire file content is in memory\n";
 
-  }else{
-      exit(1);
+  } else {
+    exit(1);
   }
 
-    uint16_t numChannels = memblock[22];
-    numChannels |= memblock[23];
+  uint16_t numChannels = memblock[22];
+  numChannels |= memblock[23];
 
   // Get the sample rate of the wav file
-    uint32_t sampleRate = memblock[24];
-    sampleRate |= memblock[25] << 8;
-    sampleRate |= memblock[26] << 16;
-    sampleRate |= memblock[27] << 24;
-    cout << "Sample Rate " << sampleRate << "\n";
+  uint32_t sampleRate = memblock[24];
+  sampleRate |= memblock[25] << 8;
+  sampleRate |= memblock[26] << 16;
+  sampleRate |= memblock[27] << 24;
+  cout << "Sample Rate " << sampleRate << "\n";
 
-    // Calculate the required delay based on sample rate
-    sampleDelay = (1000000.0 / sampleRate * 32) - 1;
-    cout << "Sample Delay " << sampleDelay << "\n";
-
-
-    // Data starts at byte 44, after the .wav header as long as there is no metadata
-    int32_t filePos = 44;
-    cout << "Output via radio...\n";
-
-    sampleDelay /= numChannels;
-    sampleRate *= numChannels;
-    sampleDelay-=80;//620 for 2MBPS, 790 for 1MBPS
+  // Calculate the required delay based on sample rate
+  sampleDelay = (1000000.0 / sampleRate * 32) - 1;
+  cout << "Sample Delay " << sampleDelay << "\n";
 
 
-    //radio.flush_tx();
-    radio.setAutoAck(0,1);
-    radio.openWritingPipe(pipes[2]);
-    radio.writeFast(&sampleRate,4);
-    radio.txStandBy();
-    radio.setAutoAck(0,0);
-    radio.openWritingPipe(pipes[1]);
-    delay(50); //Give the recipient a ms or two to process and setup timers, DAC, ADC
-    uint32_t dTimer = 0;
+  // Data starts at byte 44, after the .wav header as long as there is no metadata
+  int32_t filePos = 44;
+  cout << "Output via radio...\n";
 
-    while (1){
+  sampleDelay /= numChannels;
+  sampleRate *= numChannels;
+  sampleDelay -= 80; //620 for 2MBPS, 790 for 1MBPS
 
-      radio.stopListening();
-      radio.writeFast(&memblock[filePos],32, 1);
-      ++writes;
 
-      delayMicroseconds(sampleDelay);
-      filePos+=32;
-      if(filePos >= sz){
-        break;
-      }
-      if(millis()-dTimer>1000){
-        dTimer=millis();
-	    printf("%d %d\n",reads,writes);
-        reads=writes=0;
-        printf("%d %d %d %d\n",bufR[0],bufR[1],bufR[2],bufR[3]);
-      }
-} // loop
+  //radio.flush_tx();
+  radio.setAutoAck(0, 1);
+  radio.openWritingPipe(pipes[2]);
+  radio.writeFast(&sampleRate, 4);
+  radio.txStandBy();
+  radio.setAutoAck(0, 0);
+  radio.openWritingPipe(pipes[1]);
+  delay(50); //Give the recipient a ms or two to process and setup timers, DAC, ADC
+  uint32_t dTimer = 0;
 
-cout << "Complete, exit...\n";
-delete[] memblock;
+  while (1) {
+
+    radio.stopListening();
+    radio.writeFast(&memblock[filePos], 32, 1);
+    ++writes;
+
+    delayMicroseconds(sampleDelay);
+    filePos += 32;
+    if (filePos >= sz) {
+      break;
+    }
+    if (millis() - dTimer > 1000) {
+      dTimer = millis();
+      printf("%d %d\n", reads, writes);
+      reads = writes = 0;
+      printf("%d %d %d %d\n", bufR[0], bufR[1], bufR[2], bufR[3]);
+    }
+  } // loop
+
+  cout << "Complete, exit...\n";
+  delete[] memblock;
 
 } // main
 
 
 
 
-void intHandler(){
+void intHandler() {
 
-    if(radio.available()){
-      radio.read(&bufR,32);
-      ++reads;
-    }else{
-      radio.txStandBy();
-      radio.startListening();
-    }
+  if (radio.available()) {
+    radio.read(&bufR, 32);
+    ++reads;
+  } else {
+    radio.txStandBy();
+    radio.startListening();
+  }
 }
 
 

--- a/examples/WirelessTx_RPi/radioRelay.cpp
+++ b/examples/WirelessTx_RPi/radioRelay.cpp
@@ -45,35 +45,35 @@ int main(int argc, char** argv){
   cout << "RF24Audio On Rpi\n";
 
   // Configure radio settings for RF24Audio
-  radio.begin(); 
+  radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_MAX);
   radio.setDataRate(RF24_1MBPS);
-  radio.setAutoAck(0); 
+  radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
 
   radio.openWritingPipe(pipes[1]);
-  radio.openReadingPipe(1,pipes[0]);
+  radio.openReadingPipe(1, pipes[0]);
   radio.startListening();
   radio.txDelay = 0;
   radio.printDetails();
   radio.stopListening();
-  
-  radio.maskIRQ(0,1,0);
+
+  radio.maskIRQ(0, 1, 0);
   radio.stopListening();
-  
+
   attachInterrupt(24, INT_EDGE_FALLING, intHandler);
-  
+
   uint32_t sampleDelay = 2000;
-  
+
   // Read the entire wav file into memory
   streampos size;
   char * memblock;
-  
+
   ifstream file (audioFile, ios::in|ios::binary|ios::ate);
   if (file.is_open()){
-      
+
     size = file.tellg();//file.tellg();
     sz = file.tellg();
     printf("%d\n",sz);
@@ -81,36 +81,36 @@ int main(int argc, char** argv){
     file.seekg (0, ios::beg);
     file.read (memblock, sz);
     file.close();
-    cout << "the entire file content is in memory\n";   
-    
+    cout << "the entire file content is in memory\n";
+
   }else{
       exit(1);
   }
-  
+
     uint16_t numChannels = memblock[22];
     numChannels |= memblock[23];
-    
+
   // Get the sample rate of the wav file
     uint32_t sampleRate = memblock[24];
     sampleRate |= memblock[25] << 8;
     sampleRate |= memblock[26] << 16;
-    sampleRate |= memblock[27] << 24;    
-    cout << "Sample Rate " << sampleRate << "\n";      
-    
+    sampleRate |= memblock[27] << 24;
+    cout << "Sample Rate " << sampleRate << "\n";
+
     // Calculate the required delay based on sample rate
     sampleDelay = (1000000.0 / sampleRate * 32) - 1;
-    cout << "Sample Delay " << sampleDelay << "\n";    
-    
-    
+    cout << "Sample Delay " << sampleDelay << "\n";
+
+
     // Data starts at byte 44, after the .wav header as long as there is no metadata
-    int32_t filePos = 44;    
-    cout << "Output via radio...\n";    
-    
+    int32_t filePos = 44;
+    cout << "Output via radio...\n";
+
     sampleDelay /= numChannels;
     sampleRate *= numChannels;
     sampleDelay-=80;//620 for 2MBPS, 790 for 1MBPS
-   
-    
+
+
     //radio.flush_tx();
     radio.setAutoAck(0,1);
     radio.openWritingPipe(pipes[2]);
@@ -120,17 +120,17 @@ int main(int argc, char** argv){
     radio.openWritingPipe(pipes[1]);
     delay(50); //Give the recipient a ms or two to process and setup timers, DAC, ADC
     uint32_t dTimer = 0;
-    
-    while (1){        
-     
+
+    while (1){
+
       radio.stopListening();
-      radio.writeFast(&memblock[filePos],32,1);
+      radio.writeFast(&memblock[filePos],32, 1);
       ++writes;
 
       delayMicroseconds(sampleDelay);
       filePos+=32;
       if(filePos >= sz){
-        break;          
+        break;
       }
       if(millis()-dTimer>1000){
         dTimer=millis();
@@ -140,7 +140,7 @@ int main(int argc, char** argv){
       }
 } // loop
 
-cout << "Complete, exit...\n";  
+cout << "Complete, exit...\n";
 delete[] memblock;
 
 } // main
@@ -152,7 +152,7 @@ void intHandler(){
 
     if(radio.available()){
       radio.read(&bufR,32);
-      ++reads;      
+      ++reads;
     }else{
       radio.txStandBy();
       radio.startListening();

--- a/examples/WirelessTx_RPi/wirelessSpeaker.cpp
+++ b/examples/WirelessTx_RPi/wirelessSpeaker.cpp
@@ -43,33 +43,33 @@ int main(int argc, char** argv){
   cout << "RF24Audio On Rpi\n";
 
   // Configure radio settings for RF24Audio
-  radio.begin(); 
+  radio.begin();
   radio.setChannel(1);
   radio.setPALevel(RF24_PA_MAX);
   radio.setDataRate(RF24_1MBPS);
-  radio.setAutoAck(0); 
+  radio.setAutoAck(0);
   radio.setCRCLength(RF24_CRC_8);
   radio.setAddressWidth(5);
 
   radio.openWritingPipe(pipes[1]);
-  radio.openReadingPipe(1,pipes[0]);
+  radio.openReadingPipe(1, pipes[0]);
   radio.startListening();
   radio.txDelay = 0;
   radio.printDetails();
   radio.stopListening();
-  
+
   radio.stopListening();
 
-  
+
   uint32_t sampleDelay = 2000;
-  
+
   // Read the entire wav file into memory
   streampos size;
   char * memblock;
-  
+
   ifstream file (audioFile, ios::in|ios::binary|ios::ate);
   if (file.is_open()){
-      
+
     size = file.tellg();//file.tellg();
     sz = file.tellg();
     printf("%d\n",sz);
@@ -77,33 +77,33 @@ int main(int argc, char** argv){
     file.seekg (0, ios::beg);
     file.read (memblock, sz);
     file.close();
-    cout << "the entire file content is in memory\n";   
-    
+    cout << "the entire file content is in memory\n";
+
   }else{
       exit(1);
   }
-  
+
   // Get the sample rate of the wav file
     uint32_t sampleRate = memblock[24];
     sampleRate |= memblock[25] << 8;
     sampleRate |= memblock[26] << 16;
-    sampleRate |= memblock[27] << 24;    
-    cout << "Sample Rate " << sampleRate << "\n";      
-    
+    sampleRate |= memblock[27] << 24;
+    cout << "Sample Rate " << sampleRate << "\n";
+
     // Calculate the required delay based on sample rate
     sampleDelay = (1000000.0 / sampleRate * 32) - 1;
-    cout << "Sample Delay " << sampleDelay << "\n";    
-    
-    
+    cout << "Sample Delay " << sampleDelay << "\n";
+
+
     // Data starts at byte 44, after the .wav header as long as there is no metadata
-    int32_t filePos = 44;    
-    cout << "Output via radio...\n";    
-    
+    int32_t filePos = 44;
+    cout << "Output via radio...\n";
+
     //Sending 16-bit/2-Byte samples, so need double sample rate
     sampleDelay/=2;
     //Slight offset to ensure sample rate is close to accurate
     sampleDelay-=48;
-    
+
     //Send the sample rate to the wireless speaker using acknowledged payloads
     radio.setAutoAck(0,1);
     radio.openWritingPipe(pipes[2]);
@@ -116,17 +116,17 @@ int main(int argc, char** argv){
 
 
     uint32_t dTimer = 0;
-    
-    while (1){        
-     
-      radio.writeFast(&memblock[filePos],32,1);
-      
+
+    while (1){
+
+      radio.writeFast(&memblock[filePos],32, 1);
+
       ++writes;
 
       delayMicroseconds(sampleDelay);
       filePos+=32;
       if(filePos >= sz){
-        break;          
+        break;
       }
       if(millis()-dTimer>1000){
         dTimer=millis();
@@ -136,7 +136,7 @@ int main(int argc, char** argv){
       }
 } // loop
 
-cout << "Complete, exit...\n";  
+cout << "Complete, exit...\n";
 delete[] memblock;
 
 } // main

--- a/examples/WirelessTx_RPi/wirelessSpeaker.cpp
+++ b/examples/WirelessTx_RPi/wirelessSpeaker.cpp
@@ -23,7 +23,7 @@ using namespace std;
 
 /****************** Raspberry Pi ***********************/
 
-RF24 radio(25,0);
+RF24 radio(25, 0);
 
 // File should be mono, wav format
 char audioFile[] = "Guitar16b44kMono.wav";
@@ -32,13 +32,13 @@ char audioFile[] = "Guitar16b44kMono.wav";
 /**************************************************************/
 
 // The addresses used in RF24Audio
-const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL, 0x544d52683CLL,0x544d526846LL, 0x544d526850LL,0x544d52685ALL, 0x544d526820LL, 0x544d52686ELL, 0x544d52684BLL, 0x544d526841LL, 0x544d526855LL,0x544d52685FLL,0x544d526869LL};
+const uint64_t pipes[14] = { 0xABCDABCD71LL, 0x544d52687CLL, 0x544d526832LL, 0x544d52683CLL, 0x544d526846LL, 0x544d526850LL, 0x544d52685ALL, 0x544d526820LL, 0x544d52686ELL, 0x544d52684BLL, 0x544d526841LL, 0x544d526855LL, 0x544d52685FLL, 0x544d526869LL};
 unsigned int sz = 0;
 void intHandler();
-uint32_t reads = 0,writes = 0;
+uint32_t reads = 0, writes = 0;
 uint8_t bufR[32];
 
-int main(int argc, char** argv){
+int main(int argc, char** argv) {
 
   cout << "RF24Audio On Rpi\n";
 
@@ -67,77 +67,77 @@ int main(int argc, char** argv){
   streampos size;
   char * memblock;
 
-  ifstream file (audioFile, ios::in|ios::binary|ios::ate);
-  if (file.is_open()){
+  ifstream file (audioFile, ios::in | ios::binary | ios::ate);
+  if (file.is_open()) {
 
     size = file.tellg();//file.tellg();
     sz = file.tellg();
-    printf("%d\n",sz);
+    printf("%d\n", sz);
     memblock = new char [sz];
     file.seekg (0, ios::beg);
     file.read (memblock, sz);
     file.close();
     cout << "the entire file content is in memory\n";
 
-  }else{
-      exit(1);
+  } else {
+    exit(1);
   }
 
   // Get the sample rate of the wav file
-    uint32_t sampleRate = memblock[24];
-    sampleRate |= memblock[25] << 8;
-    sampleRate |= memblock[26] << 16;
-    sampleRate |= memblock[27] << 24;
-    cout << "Sample Rate " << sampleRate << "\n";
+  uint32_t sampleRate = memblock[24];
+  sampleRate |= memblock[25] << 8;
+  sampleRate |= memblock[26] << 16;
+  sampleRate |= memblock[27] << 24;
+  cout << "Sample Rate " << sampleRate << "\n";
 
-    // Calculate the required delay based on sample rate
-    sampleDelay = (1000000.0 / sampleRate * 32) - 1;
-    cout << "Sample Delay " << sampleDelay << "\n";
-
-
-    // Data starts at byte 44, after the .wav header as long as there is no metadata
-    int32_t filePos = 44;
-    cout << "Output via radio...\n";
-
-    //Sending 16-bit/2-Byte samples, so need double sample rate
-    sampleDelay/=2;
-    //Slight offset to ensure sample rate is close to accurate
-    sampleDelay-=48;
-
-    //Send the sample rate to the wireless speaker using acknowledged payloads
-    radio.setAutoAck(0,1);
-    radio.openWritingPipe(pipes[2]);
-    radio.writeFast(&sampleRate,4);
-    radio.txStandBy();
-    //Disable autoack/use multicast and change to the multicast pipe
-    radio.setAutoAck(0,0);
-    radio.openWritingPipe(pipes[1]);
-    delay(50); //Give the recipient a ms or two to process and setup timers, DAC, ADC
+  // Calculate the required delay based on sample rate
+  sampleDelay = (1000000.0 / sampleRate * 32) - 1;
+  cout << "Sample Delay " << sampleDelay << "\n";
 
 
-    uint32_t dTimer = 0;
+  // Data starts at byte 44, after the .wav header as long as there is no metadata
+  int32_t filePos = 44;
+  cout << "Output via radio...\n";
 
-    while (1){
+  //Sending 16-bit/2-Byte samples, so need double sample rate
+  sampleDelay /= 2;
+  //Slight offset to ensure sample rate is close to accurate
+  sampleDelay -= 48;
 
-      radio.writeFast(&memblock[filePos],32, 1);
+  //Send the sample rate to the wireless speaker using acknowledged payloads
+  radio.setAutoAck(0, 1);
+  radio.openWritingPipe(pipes[2]);
+  radio.writeFast(&sampleRate, 4);
+  radio.txStandBy();
+  //Disable autoack/use multicast and change to the multicast pipe
+  radio.setAutoAck(0, 0);
+  radio.openWritingPipe(pipes[1]);
+  delay(50); //Give the recipient a ms or two to process and setup timers, DAC, ADC
 
-      ++writes;
 
-      delayMicroseconds(sampleDelay);
-      filePos+=32;
-      if(filePos >= sz){
-        break;
-      }
-      if(millis()-dTimer>1000){
-        dTimer=millis();
-	    printf("%d %d\n",reads,writes);
-        reads=writes=0;
-        printf("%d %d %d %d\n",bufR[0],bufR[1],bufR[2],bufR[3]);
-      }
-} // loop
+  uint32_t dTimer = 0;
 
-cout << "Complete, exit...\n";
-delete[] memblock;
+  while (1) {
+
+    radio.writeFast(&memblock[filePos], 32, 1);
+
+    ++writes;
+
+    delayMicroseconds(sampleDelay);
+    filePos += 32;
+    if (filePos >= sz) {
+      break;
+    }
+    if (millis() - dTimer > 1000) {
+      dTimer = millis();
+      printf("%d %d\n", reads, writes);
+      reads = writes = 0;
+      printf("%d %d %d %d\n", bufR[0], bufR[1], bufR[2], bufR[3]);
+    }
+  } // loop
+
+  cout << "Complete, exit...\n";
+  delete[] memblock;
 
 } // main
 

--- a/src/AutoAnalogAudio.h
+++ b/src/AutoAnalogAudio.h
@@ -35,7 +35,7 @@
 
 class AutoAnalog
 {
-    
+
 public:
 
   /**
@@ -47,14 +47,14 @@ public:
 
   AutoAnalog();
 
-  /** Setup the timer(s) */ 
-  void begin(bool enADC, bool enDAC);          
-  
+  /** Setup the timer(s) */
+  void begin(bool enADC, bool enDAC);
+
   /**
    * @note This function is no longer required and does nothing
    */
-  void triggerADC();                           
-  
+  void triggerADC();
+
   /** Load the current ADC data into the ADC Data Buffer
     *
     * @param samples The number of samples to retrieve from the ADC
@@ -63,60 +63,60 @@ public:
     * buffer has been returned with the previous number of samples
     *
     */
-  void getADC(uint32_t samples = MAX_BUFFER_SIZE);                               
-  
-  /** Feed the current PCM/WAV data into the DAC for playback 
-   * 
+  void getADC(uint32_t samples = MAX_BUFFER_SIZE);
+
+  /** Feed the current PCM/WAV data into the DAC for playback
+   *
    * @param dacChannel 0 for DAC0, 1 for DAC1, 2 for alternating DAC0/DAC1
    * @param samples The number of samples to send to the DAC
    * @param startInterrupts Only used for the ESP32, this will enable an RTOS task to handle DAC
    */
-  void feedDAC(uint8_t dacChannel = 0, uint32_t samples = MAX_BUFFER_SIZE, bool startInterrupts = false);                              
+  void feedDAC(uint8_t dacChannel = 0, uint32_t samples = MAX_BUFFER_SIZE, bool startInterrupts = false);
 
-  /** DAC data buffer for 8-bit samples 
+  /** DAC data buffer for 8-bit samples
    *
    *  8-bit user samples are loaded directly into this buffer before calling feedDAC() <br>
    *  @see dacBitsPerSample
    */
-  uint8_t dacBuffer[MAX_BUFFER_SIZE];        
-   
-  /** ADC Data buffer for 8-bit samples 
+  uint8_t dacBuffer[MAX_BUFFER_SIZE];
+
+  /** ADC Data buffer for 8-bit samples
    *
    *  8-bit samples are read directly from this buffer after calling getADC() <br>
    * @see adcBitsPerSample
    */
-  uint8_t adcBuffer[MAX_BUFFER_SIZE];          
+  uint8_t adcBuffer[MAX_BUFFER_SIZE];
 
-  /** DAC data buffer for 10 or 12-bit samples 
+  /** DAC data buffer for 10 or 12-bit samples
    *
    *  10 or 12-bit user samples are loaded directly into this buffer before calling feedDAC() <br>
    * @see dacBitsPerSample
    */
-  uint16_t dacBuffer16[MAX_BUFFER_SIZE];          
-   
-  /** ADC Data buffer for 10 or 12-bit samples 
+  uint16_t dacBuffer16[MAX_BUFFER_SIZE];
+
+  /** ADC Data buffer for 10 or 12-bit samples
    *
    *  10 or 12-bit samples are read directly from this buffer after calling getADC() <br>
    * @see adcBitsPerSample
    */
-  uint16_t adcBuffer16[MAX_BUFFER_SIZE];    
+  uint16_t adcBuffer16[MAX_BUFFER_SIZE];
 
   /** Set sample rate. 0 enables the default rate specified in AutoAnalog_config.h
    * @param sampRate This sets the defined sample rate ie: 32000 is 32Khz
    * @param stereo Only used for the ESP32, this sets stereo or mono output and affects the sample rate
   */
-  void setSampleRate(uint32_t sampRate = 0, bool stereo = true);   
-  
-  /** Function called by DAC IRQ */ 
-  void dacHandler(void);                                  
-   
+  void setSampleRate(uint32_t sampRate = 0, bool stereo = true);
+
+  /** Function called by DAC IRQ */
+  void dacHandler(void);
+
   /** Auto & Manual sample rates. En/Disables automatic adjustment of timers
    *
    *  Default: true
    **/
   bool autoAdjust;
-  
-  
+
+
   /** ADC (Analog to Digital Converter) <br>
    * Select the bits-per-sample for incoming data <br>
    * Default: 8:8-bit, 10:10-bit, 12:12-bit <br>
@@ -126,7 +126,7 @@ public:
    * adcBuffer16[] is a 16-bit buffer used solely for placing your 10 and 12-bit samples <br>
    **/
   uint8_t adcBitsPerSample;
-  
+
   /** DAC (Digital to Analog Converter) <br>
    * Select the bits-per-sample for incoming data <br>
    * Default: 8:8-bit, 10:10-bit, 12:12-bit <br>
@@ -137,7 +137,7 @@ public:
    *
    **/
   uint8_t dacBitsPerSample;
-  
+
   /**
    * Enable reads from the specified channel (pins A0-A6)
    *
@@ -152,27 +152,27 @@ public:
    * @note Specify pins numerically: 0=A0, 1=A1, etc...
    */
   void disableAdcChannel(uint8_t pinAx);
-  
+
   /**
    * Disable the DAC
    * @param withinTask Only used for ESP32, set to true if calling from within a task itself, see included example
    */
   void disableDAC(bool withinTask = false);
-  
+
   /**
    * En/Disable the interrupt for the ADC
-   * 
+   *
    * If enabled, the following function needs to be added:
    * @code
    * void ADC_Handler(void){
-   *  -code here-    
+   *  -code here-
    * }
    * @endcode
    */
   void adcInterrupts(bool enabled = true);
-  
+
   void dacInterrupts(bool enabled = true, bool withinTask = false);
-  
+
   #if defined ESP32
     /** Rampout and RampIn functions ramp the signal in/out to minimize 'pop' sound made when en/disabling the DAC
 	 * @param sample For ESP32 only, provide the first or last sample to ramp the signal in/out
@@ -180,10 +180,10 @@ public:
     void rampOut(uint8_t sample);
     void rampIn(uint8_t sample);
     TaskHandle_t dacTaskHandle;
-  #endif 
-  
+  #endif
+
   /**@}*/
-  
+
 private:
 
   /**
@@ -194,16 +194,16 @@ private:
    *  may want to extend this class.
    */
   /**@{*/
-#if defined (ARDUINO_ARCH_SAM)  
+#if defined (ARDUINO_ARCH_SAM)
   bool whichDma = 0;
   bool whichDac;
   bool dacChan;
-  
+
   uint8_t aCtr = 0;                    /* Internal counter for ADC data */
   uint16_t realBuf[MAX_BUFFER_SIZE];   /* Internal DAC buffer */
-  uint16_t adcDma[MAX_BUFFER_SIZE]; /* Buffers for ADC DMA transfers */  
-  uint16_t dataReady;                  /* Internal indicator for DAC data */ 
-  
+  uint16_t adcDma[MAX_BUFFER_SIZE]; /* Buffers for ADC DMA transfers */
+  uint16_t dataReady;                  /* Internal indicator for DAC data */
+
   uint32_t dataTimer;                  /* Internal timer tracks timing of incoming data */
   uint32_t sampleCount;                /* Internal counter for delaying analysis of timing */
   uint32_t tcTicks;                    /* Stores the current TC0 Ch0 counter value */
@@ -218,10 +218,10 @@ private:
 #endif
   void adcSetup(void);                 /* Enable the ADC */
   void dacSetup(void);                 /* Enable the DAC */
-  
+
   void dacBufferStereo(uint8_t dacChannel);
-  
-  void tcSetup(uint32_t sampRate = 0);      /* Sets up Timer TC0 Channel 0 */  
+
+  void tcSetup(uint32_t sampRate = 0);      /* Sets up Timer TC0 Channel 0 */
   void tc2Setup(uint32_t sampRate = 0);     /* Sets up Timer TC0 Channel 1 */
 
   uint32_t frequencyToTimerCount(uint32_t Frequency); /* Function to calculate timer counters */
@@ -230,20 +230,20 @@ private:
 
   uint32_t sampleRate;
   i2s_config_t i2s_cfg;
-  
+
   bool i2sStopped;
-  
-  
+
+
   bool taskCreated;
 
   bool dacEnabled;
   uint8_t lastDacSample;
   i2s_event_t myI2SQueue[5];
   //void dacTask(void *args);
-  
+
   bool adcTaskCreated;
   bool adcDisabled;
-  
+
   #define DELAY_250MS (250 / portTICK_PERIOD_MS)
 
 #endif
@@ -260,23 +260,16 @@ private:
  * <b>For Arduino Due</b><br>
  *
  * * Audio Relay & Peripheral Test Example:
-* This example demonstrates how to manage incoming and outgoing audio streams using 
-* the AAAudio library and nrf24l01+ radio modules on Arduino Due.
-* 
-* 1. This example uses the onboard DAC to play the incoming audio data via DAC0
-* 2. The ADC is used to sample the DAC0 pin, and the data is made available
-* 3. The data is re-broadcast over the radios
-* 4. Incoming radio data can be directly re-broadcast, but this example is a test of all peripherals
-*
-*/
-
-/**
- * @example myRadio.h
- * <b>For Arduino Due</b><br>
+ * This example demonstrates how to manage incoming and outgoing audio streams using
+ * the AAAudio library and nrf24l01+ radio modules on Arduino Due.
  *
- * * Include file for nrf24l01+ radios:
- * 
- * Contains the settings and config used for the radio examples
+ * 1. This example uses the onboard DAC to play the incoming audio data via DAC0
+ * 2. The ADC is used to sample the DAC0 pin, and the data is made available
+ * 3. The data is re-broadcast over the radios
+ * 4. Incoming radio data can be directly re-broadcast, but this example is a test of all peripherals
+ *
+ * @note This code depends on [radio.h](AudioRadioRelay_2myRadio_8h_source.html)
+ * located in the same directory.
  */
 
 /**
@@ -289,6 +282,9 @@ private:
  *  the audio via radio
  *
  *  Send a number 1 or 2 over Serial to change frequency, +/- to adjust volume
+ *
+ * @note This code depends on [radio.h](SimpleSine_2myRadio_8h_source.html)
+ * located in the same directory.
  */
 
 /**
@@ -300,9 +296,9 @@ private:
  *  This example demonstrates simple generation of a 12-bit sine wave
  *
  *  Send a number 1 or 2 over Serial to change frequency, +/- to adjust volume
- */ 
- 
- /**
+ */
+
+/**
  * @example WirelessSpeaker.ino
  * <b>For Arduino Due</b><br>
  *
@@ -312,9 +308,12 @@ private:
  *
  *  The incoming audio format is 16bit mono <br>
  *  NRF24L01+ radios can support around 16-44khz sample rate w/16-bit samples, 88khz+ with 8-bit samples
- */ 
- 
-  /**
+ *
+ * @note This code depends on [radio.h](WirelessSpeaker_2myRadio_8h_source.html)
+ * located in the same directory.
+ */
+
+/**
  * @example WirelessMicrophone.ino
  * <b>For Arduino Due</b><br>
  *
@@ -324,9 +323,12 @@ private:
  *
  *  The outgoing audio format is 8bit, mono, 16khz <br>
  *  NRF24L01+ radios can support around 16-44khz sample rate w/12-bit samples, 88khz+ with 8-bit samples
- */ 
- 
- /**
+ *
+ * @note This code depends on [radio.h](WirelessMicrophone_2myRadio_8h_source.html)
+ * located in the same directory.
+ */
+
+/**
  * @example SimpleAdcStream.ino
  * <b>For Arduino Due</b><br>
  *
@@ -335,8 +337,8 @@ private:
  *  This example demonstrates how to capture a steady stream of ADC data
  *
  *  See AnalogAudio_config.h to change the MAX_BUFFER_SIZE allowing larger chunks
- */ 
- 
+ */
+
 /**
  * @example MultiChannelAdcStream.ino
  * <b>For Arduino Due</b><br>
@@ -348,9 +350,9 @@ private:
  *
  *  See AnalogAudio_config.h to change the MAX_BUFFER_SIZE allowing larger chunks of data
  */
- 
+
 /**
- * @example SDAudioBasic.ino
+ * @example SdAudioBasic.ino
  * <b>For Arduino Due</b><br>
  *
  * * Basic SDAudio Example:
@@ -358,9 +360,9 @@ private:
  *  This example demonstrates how to play *.wav files from SD Card.
  *
  */
- 
+
 /**
- * @example SDAudioAuto.ino
+ * @example SdAudioAuto.ino
  * <b>For Arduino Due</b><br>
  *
  * * Auto SDAudio Example:
@@ -370,7 +372,7 @@ private:
  */
 
 /**
- * @example SDAudioWavPlayer.ino
+ * @example SdAudioWavPlayer.ino
  * <b>For Arduino Due</b><br>
  *
  * * Wav Player SDAudio Example:
@@ -378,9 +380,9 @@ private:
  *  This example demonstrates a simple *.wav player with a few features
  *
  */
- 
+
 /**
- * @example SDAudioRecording.ino
+ * @example SdAudioRecording.ino
  * <b>For Arduino Due</b><br>
  *
  * * Wav Recording SDAudio Example:
@@ -388,12 +390,12 @@ private:
  *  This example demonstrates recording standard format *.wav files
  *  for playback on any PC or audio device.
  */
- 
- /**
+
+/**
  * @mainpage Automatic Analog Audio Library for Arduino
  *
  * @section LibInfo Auto Analog Audio (Automatic DAC, ADC & Timer) library
- * 
+ *
  * **Goals:**
  *
  * **Extremely low-latency digital audio recording, playback, communication and relaying at high speeds**
@@ -411,10 +413,10 @@ private:
  * - ADC & DAC: 8, 10 or 12-bit sampling
  * - Single channel or stereo output
  * - Multi-channel ADC sampling
- * 
  *
  *
- * The library internally configures timing based on user driven data requests or delivery, making data available or processing 
+ *
+ * The library internally configures timing based on user driven data requests or delivery, making data available or processing
  * it at the appropriate speed without delays or while() loops.
  *
  * The library can also be configured to operate at a set sample rate, with the getADC() and feedDAC() functions blocking until data
@@ -425,4 +427,3 @@ private:
  * http://tmrh20.blogspot.com <br>
  *
  */
- 


### PR DESCRIPTION
I removed broken attempt to show *radio.h* as a separate example (ambiguous due to 4 copies) and respectively added `@note` admonished links to each example's description that uses a *radio.h* file. As always adjusted README, Doxyfile, & custom-doxygen.css files accordingly.

I also ran all the examples through the AStyle formatter using Arduino IDE compatible settings (same conf file found in RF24/examples folder)